### PR TITLE
Add new legacy revision with Dec2025 points update and WaT release

### DIFF
--- a/X2PO/dec2025/firstorder.json
+++ b/X2PO/dec2025/firstorder.json
@@ -1,0 +1,1178 @@
+{
+    "Gozanti-class Cruiser": {
+        "firstordersympathizers": {
+            "name": "First Order Sympathizers",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 66,
+            "slots": [
+                "Command",
+                "Hardpoint",
+                "Crew",
+                "Crew",
+                "Gunner",
+                "Team",
+                "Cargo",
+                "Cargo"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "Yes"
+        }
+    },
+    "Raider-class Corvette": {
+        "firstordercollaborators": {
+            "name": "First Order Collaborators",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 131,
+            "slots": [
+                "Command",
+                "Torpedo",
+                "Missile",
+                "Hardpoint",
+                "Hardpoint",
+                "Crew",
+                "Crew",
+                "Team",
+                "Team",
+                "Cargo"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "Yes"
+        }
+    },
+    "TIE/ba Interceptor": {
+        "majorvonreg": {
+            "name": "Major Vonreg",
+            "subtitle": "Red Baron",
+            "limited": 1,
+            "cost": 54,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "holo": {
+            "name": "“Holo”",
+            "subtitle": "Trick of the Light",
+            "limited": 1,
+            "cost": 52,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ember": {
+            "name": "“Ember”",
+            "subtitle": "Dying Flame",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "firstorderprovocateur": {
+            "name": "First Order Provocateur",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "TIE/fo Fighter": {
+        "midnight": {
+            "name": "“Midnight”",
+            "subtitle": "Omega Leader",
+            "limited": 1,
+            "cost": 34,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "commandermalarus": {
+            "name": "Commander Malarus",
+            "subtitle": "First Order Enforcer",
+            "limited": 1,
+            "cost": 34,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "scorch": {
+            "name": "“Scorch”",
+            "subtitle": "Zeta Leader",
+            "limited": 1,
+            "cost": 33,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "static": {
+            "name": "“Static”",
+            "subtitle": "Omega Ace",
+            "limited": 1,
+            "cost": 29,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "longshot": {
+            "name": "“Longshot”",
+            "subtitle": "Zeta Ace",
+            "limited": 1,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "omegasquadronace": {
+            "name": "Omega Squadron Ace",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 28,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "muse": {
+            "name": "“Muse”",
+            "subtitle": "Epsilon Leader",
+            "limited": 1,
+            "cost": 29,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "tn3465": {
+            "name": "TN-3465",
+            "subtitle": "Loose End",
+            "limited": 1,
+            "cost": 27,
+            "slots": [
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "zetasquadronpilot": {
+            "name": "Zeta Squadron Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 27,
+            "slots": [
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "epsilonsquadroncadet": {
+            "name": "Epsilon Squadron Cadet",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 26,
+            "slots": [
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lieutenantrivas": {
+            "name": "Lieutenant Rivas",
+            "subtitle": "Inconvenient Witness",
+            "limited": 1,
+            "cost": 27,
+            "slots": [
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "null": {
+            "name": "“Null”",
+            "subtitle": "Epsilon Ace",
+            "limited": 1,
+            "cost": 29,
+            "slots": [
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lieutenantgalek": {
+            "name": "Lieutenant Galek",
+            "subtitle": "Harsh Instructor",
+            "limited": 1,
+            "cost": 31,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dt798": {
+            "name": "DT-798",
+            "subtitle": "Jace Rucklin",
+            "limited": 1,
+            "cost": 34,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lingaava": {
+            "name": "Lin Gaava",
+            "subtitle": "Impetuous Mechanic",
+            "limited": 1,
+            "cost": 32,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "fn2187-wat1": {
+            "name": "FN-2187",
+            "subtitle": "Eight-Seven",
+            "limited": 1,
+            "cost": 28,
+            "slots": [
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "TIE/sf Fighter": {
+        "quickdraw": {
+            "name": "“Quickdraw”",
+            "subtitle": "Defiant Duelist",
+            "limited": 1,
+            "cost": 42,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Gunner",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "backdraft": {
+            "name": "“Backdraft”",
+            "subtitle": "Fiery Fanatic",
+            "limited": 1,
+            "cost": 36,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Gunner",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "omegasquadronexpert": {
+            "name": "Omega Squadron Expert",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 33,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Gunner",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "zetasquadronsurvivor": {
+            "name": "Zeta Squadron Survivor",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 32,
+            "slots": [
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Gunner",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lieutenantlehuse": {
+            "name": "Lieutenant LeHuse",
+            "subtitle": "Unflinching Executioner",
+            "limited": 1,
+            "cost": 37,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Gunner",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "captainphasma": {
+            "name": "Captain Phasma",
+            "subtitle": "Scyre Survivor",
+            "limited": 1,
+            "cost": 34,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Gunner",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "strife-wat1": {
+            "name": "“Strife”",
+            "subtitle": "Committed Combatant",
+            "limited": 1,
+            "cost": 34,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Gunner",
+                "Tech"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "TIE/vn Silencer": {
+        "blackout": {
+            "name": "“Blackout”",
+            "subtitle": "Ill-Fated Test Pilot",
+            "limited": 1,
+            "cost": 60,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Missile",
+                "Tech",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "kyloren": {
+            "name": "Kylo Ren",
+            "subtitle": "Tormented Apprentice",
+            "limited": 1,
+            "cost": 79,
+            "slots": [
+                "Force Power",
+                "Torpedo",
+                "Missile",
+                "Tech",
+                "Configuration"
+            ],
+            "keywords": [
+                "Dark Side",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "firstordertestpilot": {
+            "name": "First Order Test Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 55,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Missile",
+                "Tech",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "recoil": {
+            "name": "“Recoil”",
+            "subtitle": "Quantity Over Quality",
+            "limited": 1,
+            "cost": 55,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Missile",
+                "Tech",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "avenger": {
+            "name": "“Avenger”",
+            "subtitle": "Wrathful Wingmate",
+            "limited": 1,
+            "cost": 55,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Missile",
+                "Tech",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sienarjaemusengineer": {
+            "name": "Sienar-Jaemus Engineer",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 49,
+            "slots": [
+                "Torpedo",
+                "Missile",
+                "Tech",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "rush": {
+            "name": "“Rush”",
+            "subtitle": "Adrenaline Junkie",
+            "limited": 1,
+            "cost": 57,
+            "slots": [
+                "Torpedo",
+                "Missile",
+                "Tech",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Upsilon-class command shuttle": {
+        "lieutenantdormitz": {
+            "name": "Lieutenant Dormitz",
+            "subtitle": "Hypercomms Specialist",
+            "limited": 1,
+            "cost": 64,
+            "slots": [
+                "Sensor",
+                "Cannon",
+                "Crew",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Tech",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "majorstridan": {
+            "name": "Major Stridan",
+            "subtitle": "Stentorian Commander",
+            "limited": 1,
+            "cost": 61,
+            "slots": [
+                "Sensor",
+                "Cannon",
+                "Crew",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Tech",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "pettyofficerthanisson": {
+            "name": "Petty Officer Thanisson",
+            "subtitle": "Alert Flight Controller",
+            "limited": 1,
+            "cost": 59,
+            "slots": [
+                "Sensor",
+                "Cannon",
+                "Crew",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Tech",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "starkillerbasepilot": {
+            "name": "Starkiller Base Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 58,
+            "slots": [
+                "Sensor",
+                "Cannon",
+                "Crew",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Tech",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lieutenanttavson": {
+            "name": "Lieutenant Tavson",
+            "subtitle": "Obedient Shuttle Pilot",
+            "limited": 1,
+            "cost": 64,
+            "slots": [
+                "Sensor",
+                "Cannon",
+                "Crew",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Tech",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "captaincardinal": {
+            "name": "Captain Cardinal",
+            "subtitle": "Principled Instructor",
+            "limited": 1,
+            "cost": 60,
+            "slots": [
+                "Sensor",
+                "Cannon",
+                "Crew",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Tech",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "enricpryde-wat1": {
+            "name": "Enric Pryde",
+            "subtitle": "Steadfast",
+            "limited": 1,
+            "cost": 62,
+            "slots": [
+                "Sensor",
+                "Cannon",
+                "Crew",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Tech",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Xi-class Light Shuttle": {
+        "agentterex": {
+            "name": "Agent Terex",
+            "subtitle": "Devious Provocateur",
+            "limited": 1,
+            "cost": 32,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Tech",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "commandermalarus-xiclasslightshuttle": {
+            "name": "Commander Malarus",
+            "subtitle": "Vindictive Taskmaster",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Tech",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "firstordercourier": {
+            "name": "First Order Courier",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 30,
+            "slots": [
+                "Crew",
+                "Crew",
+                "Modification",
+                "Tech",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "gideonhask-xiclasslightshuttle": {
+            "name": "Gideon Hask",
+            "subtitle": "Merciless Hard-Liner",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Tech",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "agenttierny": {
+            "name": "Agent Tierny",
+            "subtitle": "Persuasive Recruiter",
+            "limited": 1,
+            "cost": 49,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Tech",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "TIE/se Bomber": {
+        "breach": {
+            "name": "“Breach”",
+            "subtitle": "Ordnance Expert",
+            "limited": 1,
+            "cost": 37,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Torpedo",
+                "Missile",
+                "Gunner",
+                "Device",
+                "Device",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "scorch-tiesebomber": {
+            "name": "“Scorch”",
+            "subtitle": "Jad Bean",
+            "limited": 1,
+            "cost": 33,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Torpedo",
+                "Missile",
+                "Gunner",
+                "Device",
+                "Device",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dread": {
+            "name": "“Dread”",
+            "subtitle": "Devotee of Devastation",
+            "limited": 1,
+            "cost": 32,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Torpedo",
+                "Missile",
+                "Gunner",
+                "Device",
+                "Device",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "grudge": {
+            "name": "“Grudge”",
+            "subtitle": "Hateful Harrier",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Tech",
+                "Torpedo",
+                "Missile",
+                "Gunner",
+                "Device",
+                "Device",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "firstordercadet": {
+            "name": "First Order Cadet",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 32,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Torpedo",
+                "Missile",
+                "Gunner",
+                "Device",
+                "Device",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sienarjaemustestpilot": {
+            "name": "Sienar-Jaemus Test Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 31,
+            "slots": [
+                "Tech",
+                "Torpedo",
+                "Missile",
+                "Gunner",
+                "Device",
+                "Device",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "juljerjerrod": {
+            "name": "Jul Jerjerrod",
+            "subtitle": "Security Commander",
+            "limited": 1,
+            "cost": 34,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Torpedo",
+                "Missile",
+                "Gunner",
+                "Device",
+                "Device",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "TIE/wi Whisper Modified Interceptor": {
+        "kyloren-tiewiwhispermodifiedinterceptor": {
+            "name": "Kylo Ren",
+            "subtitle": "Supreme Leader of the First Order",
+            "limited": 1,
+            "cost": 61,
+            "slots": [
+                "Force Power",
+                "Talent",
+                "Missile",
+                "Tech",
+                "Tech",
+                "Configuration"
+            ],
+            "keywords": [
+                "Dark Side",
+                "Light Side",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "wrath": {
+            "name": "“Wrath”",
+            "subtitle": "Herald of Destruction",
+            "limited": 1,
+            "cost": 48,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Tech",
+                "Tech",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "nightfall": {
+            "name": "“Nightfall”",
+            "subtitle": "709th Legion Veteran",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Tech",
+                "Tech",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "whirlwind": {
+            "name": "“Whirlwind”",
+            "subtitle": "Reap What You Sow",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Tech",
+                "Tech",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "709thlegionace": {
+            "name": "709th Legion Ace",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 43,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Tech",
+                "Tech",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "redfuryzealot": {
+            "name": "Red Fury Zealot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Tech",
+                "Tech",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    }
+}

--- a/X2PO/dec2025/galacticempire.json
+++ b/X2PO/dec2025/galacticempire.json
@@ -1,0 +1,2983 @@
+{
+    "Alpha-class Star Wing": {
+        "lieutenantkarsabi": {
+            "name": "Lieutenant Karsabi",
+            "subtitle": "Brash Noble",
+            "limited": 1,
+            "cost": 33,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Torpedo",
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "majorvynder": {
+            "name": "Major Vynder",
+            "subtitle": "Pragmatic Survivor",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Torpedo",
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "nusquadronpilot": {
+            "name": "Nu Squadron Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 32,
+            "slots": [
+                "Sensor",
+                "Torpedo",
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "rhosquadronpilot": {
+            "name": "Rho Squadron Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 34,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Torpedo",
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lieutenantkarsabi-pnp": {
+            "name": "Lieutenant Karsabi",
+            "subtitle": "Payload Courier",
+            "limited": 1,
+            "cost": 5,
+            "slots": [],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "No",
+            "standardLoadout": [
+                "protontorpedoes",
+                "saturationrockets-alphaclassstarwing",
+                "electronicbaffle"
+            ]
+        },
+        "lieutenantkarsabi-pnp-lsl": {
+            "name": "Lieutenant Karsabi",
+            "subtitle": "Payload Courier",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Sensor",
+                "Torpedo",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "majorvynder-ssl": {
+            "name": "Major Vynder",
+            "subtitle": "Helping Hand",
+            "limited": 1,
+            "cost": 5,
+            "slots": [],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "No",
+            "standardLoadout": [
+                "longrangescanners-alphaclassstarwing",
+                "ioncannon",
+                "heavyplasmamissiles-alphaclassstarwing"
+            ]
+        },
+        "majorvynder-pnp-lsl": {
+            "name": "Major Vynder",
+            "subtitle": "Helping Hand",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Sensor",
+                "Torpedo",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Gauntlet Fighter": {
+        "captainhark": {
+            "name": "Captain Hark",
+            "subtitle": "Obedient Underling",
+            "limited": 1,
+            "cost": 53,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Gunner",
+                "Device",
+                "Modification",
+                "Title",
+                "Configuration"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "garsaxon": {
+            "name": "Gar Saxon",
+            "subtitle": "Treacherous Viceroy",
+            "limited": 1,
+            "cost": 61,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Gunner",
+                "Device",
+                "Modification",
+                "Title",
+                "Configuration"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "imperialsupercommando": {
+            "name": "Imperial Super Commando",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 54,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Gunner",
+                "Device",
+                "Modification",
+                "Title",
+                "Configuration"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Gozanti-class Cruiser": {
+        "outerrimgarrison": {
+            "name": "Outer Rim Garrison",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 66,
+            "slots": [
+                "Command",
+                "Hardpoint",
+                "Crew",
+                "Crew",
+                "Gunner",
+                "Team",
+                "Cargo",
+                "Cargo",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "Yes"
+        }
+    },
+    "Lambda-class T-4a Shuttle": {
+        "captainkagi": {
+            "name": "Captain Kagi",
+            "subtitle": "The Emperor’s Shuttle Pilot",
+            "limited": 1,
+            "cost": 47,
+            "slots": [
+                "Sensor",
+                "Cannon",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "coloneljendon": {
+            "name": "Colonel Jendon",
+            "subtitle": "Darth Vader’s Shuttle Pilot",
+            "limited": 1,
+            "cost": 49,
+            "slots": [
+                "Sensor",
+                "Cannon",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lieutenantsai": {
+            "name": "Lieutenant Sai",
+            "subtitle": "Death Squadron Veteran",
+            "limited": 1,
+            "cost": 45,
+            "slots": [
+                "Sensor",
+                "Cannon",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "omicrongrouppilot": {
+            "name": "Omicron Group Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 41,
+            "slots": [
+                "Sensor",
+                "Cannon",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "captainyorr-wat1": {
+            "name": "Captain Yorr",
+            "subtitle": "ST-321 Shuttle Pilot",
+            "limited": 1,
+            "cost": 47,
+            "slots": [
+                "Sensor",
+                "Cannon",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Raider-class Corvette": {
+        "outerrimpatrol": {
+            "name": "Outer Rim Patrol",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 134,
+            "slots": [
+                "Command",
+                "Torpedo",
+                "Missile",
+                "Hardpoint",
+                "Hardpoint",
+                "Crew",
+                "Crew",
+                "Team",
+                "Team",
+                "Cargo",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "Yes"
+        }
+    },
+    "TIE Advanced v1": {
+        "baronoftheempire": {
+            "name": "Baron of the Empire",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "grandinquisitor": {
+            "name": "Grand Inquisitor",
+            "subtitle": "Master of the Inquisitorious",
+            "limited": 1,
+            "cost": 52,
+            "slots": [
+                "Sensor",
+                "Missile",
+                "Force Power"
+            ],
+            "keywords": [
+                "Dark Side",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "inquisitor": {
+            "name": "Inquisitor",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 38,
+            "slots": [
+                "Sensor",
+                "Missile",
+                "Force Power"
+            ],
+            "keywords": [
+                "Dark Side",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "seventhsister": {
+            "name": "Seventh Sister",
+            "subtitle": "Sadistic Interrogator",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Sensor",
+                "Missile",
+                "Force Power"
+            ],
+            "keywords": [
+                "Dark Side",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "fifthbrother": {
+            "name": "Fifth Brother",
+            "subtitle": "Ruthless Brute",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Force Power",
+                "Sensor",
+                "Missile"
+            ],
+            "keywords": [
+                "Dark Side",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "TIE Advanced x1": {
+        "darthvader": {
+            "name": "Darth Vader",
+            "subtitle": "Black Leader",
+            "limited": 1,
+            "cost": 68,
+            "slots": [
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Force Power"
+            ],
+            "keywords": [
+                "Dark Side",
+                "Sith",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "maarekstele": {
+            "name": "Maarek Stele",
+            "subtitle": "Servant of the Empire",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "stormsquadronace": {
+            "name": "Storm Squadron Ace",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 37,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "tempestsquadronpilot": {
+            "name": "Tempest Squadron Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 35,
+            "slots": [
+                "Sensor",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "vedfoslo": {
+            "name": "Ved Foslo",
+            "subtitle": "Ambitious Engineer",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "zertikstrom": {
+            "name": "Zertik Strom",
+            "subtitle": "Pitiless Administrator",
+            "limited": 1,
+            "cost": 39,
+            "slots": [
+                "Sensor",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "darthvader-battleofyavin": {
+            "name": "Darth Vader",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 81,
+            "slots": [],
+            "keywords": [
+                "Dark Side",
+                "Sith",
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "marksmanship",
+                "hate",
+                "afterburners"
+            ]
+        },
+        "darthvader-battleofyavin-lsl": {
+            "name": "Darth Vader",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 73,
+            "slots": [
+                "Sensor",
+                "Missile",
+                "Force Power"
+            ],
+            "keywords": [
+                "Dark Side",
+                "Sith",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "junoeclipse": {
+            "name": "Juno Eclipse",
+            "subtitle": "Corulag's Finest",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "darthvader-swz105": {
+            "name": "Darth Vader",
+            "subtitle": "Black Leader",
+            "limited": 1,
+            "cost": 75,
+            "slots": [],
+            "keywords": [
+                "Dark Side",
+                "Sith",
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "hate",
+                "ionmissiles",
+                "afterburners"
+            ]
+        },
+        "maarekstele-swz105": {
+            "name": "Maarek Stele",
+            "subtitle": "Servant of the Empire",
+            "limited": 1,
+            "cost": 53,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "elusive",
+                "outmaneuver",
+                "afterburners"
+            ]
+        }
+    },
+    "TIE/in Interceptor": {
+        "alphasquadronpilot": {
+            "name": "Alpha Squadron Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 32,
+            "slots": [
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sabersquadronace": {
+            "name": "Saber Squadron Ace",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 37,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "soontirfel": {
+            "name": "Soontir Fel",
+            "subtitle": "Ace of Legend",
+            "limited": 1,
+            "cost": 56,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "turrphennir": {
+            "name": "Turr Phennir",
+            "subtitle": "Ambitious Ace",
+            "limited": 1,
+            "cost": 39,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "cienaree": {
+            "name": "Ciena Ree",
+            "subtitle": "Look Through My Eyes",
+            "limited": 1,
+            "cost": 47,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "gideonhask-tieininterceptor": {
+            "name": "Gideon Hask",
+            "subtitle": "Inferno Two",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "vultskerris-tieininterceptor": {
+            "name": "Vult Skerris",
+            "subtitle": "Arrogant Ace",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "commandantgoran": {
+            "name": "Commandant Goran",
+            "subtitle": "Skystrike Superintendent",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lieutenantlorrir": {
+            "name": "Lieutenant Lorrir",
+            "subtitle": "Requiem for Brentaal",
+            "limited": 1,
+            "cost": 37,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "nashwindrider": {
+            "name": "Nash Windrider",
+            "subtitle": "Alderaanian Zealot",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "idenversio-battleofyavin": {
+            "name": "Iden Versio",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 67,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "predator",
+                "fanatic-battleofyavin"
+            ]
+        },
+        "idenversio-battleofyavin-lsl": {
+            "name": "Iden Versio",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 64,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sigma4-battleofyavin": {
+            "name": "Sigma 4",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 52,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "disciplined",
+                "primedthrusters"
+            ]
+        },
+        "sigma4-battleofyavin-lsl": {
+            "name": "Sigma 4",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 40,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sigma5-battleofyavin": {
+            "name": "Sigma 5",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 50,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "sensorjammer-battleofyavin",
+                "elusive"
+            ]
+        },
+        "sigma5-battleofyavin-lsl": {
+            "name": "Sigma 5",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sigma6-battleofyavin": {
+            "name": "Sigma 6",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 48,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "daredevil",
+                "afterburners"
+            ]
+        },
+        "sigma6-battleofyavin-lsl": {
+            "name": "Sigma 6",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sigma7-battleofyavin": {
+            "name": "Sigma 7",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 48,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "marksmanship",
+                "firecontrolsystem"
+            ]
+        },
+        "sigma7-battleofyavin-lsl": {
+            "name": "Sigma 7",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Talent"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "secondsister": {
+            "name": "Second Sister",
+            "subtitle": "Manipulative Monster",
+            "limited": 1,
+            "cost": 47,
+            "slots": [
+                "Force Power",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Dark Side",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sapphire2-battleoverendor": {
+            "name": "Sapphire 2",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 53,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "noescape-battleoverendor",
+                "reckless-battleoverendor",
+                "primedthrusters",
+                "targetingmatrix-battleoverendor"
+            ]
+        },
+        "sapphire2-battleoverendor-lsl": {
+            "name": "Sapphire 2",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Modification",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "soontirfel-battleoverendor": {
+            "name": "Soontir Fel",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 68,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "apexpredator-battleoverendor",
+                "noescape-battleoverendor",
+                "blanksignature-battleoverendor",
+                "feedbackemitter-battleoverendor"
+            ]
+        },
+        "soontirfel-battleoverendor-lsl": {
+            "name": "Soontir Fel",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 49,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "mausmonare-battleoverendor": {
+            "name": "Maus Monare",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 56,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "noescape-battleoverendor",
+                "outmaneuver",
+                "fuelinjectionoverride-battleoverendor"
+            ]
+        },
+        "mausmonare-battleoverendor-lsl": {
+            "name": "Maus Monare",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 42,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "carnorjax-wat1": {
+            "name": "Carnor Jax",
+            "subtitle": "Emperor's Revenge",
+            "limited": 1,
+            "cost": 49,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "TIE Reaper": {
+        "vizier": {
+            "name": "“Vizier”",
+            "subtitle": "Ruthless Tactician",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Crew",
+                "Crew",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "captainferoph": {
+            "name": "Captain Feroph",
+            "subtitle": "Imperial Courier",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Crew",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "majorvermeil": {
+            "name": "Major Vermeil",
+            "subtitle": "Veteran of Scarif",
+            "limited": 1,
+            "cost": 48,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Crew",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "scarifbasepilot": {
+            "name": "Scarif Base Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 38,
+            "slots": [
+                "Crew",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "TIE/D Defender": {
+        "colonelvessery": {
+            "name": "Colonel Vessery",
+            "subtitle": "Contemplative Commander",
+            "limited": 1,
+            "cost": 78,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "countessryad": {
+            "name": "Countess Ryad",
+            "subtitle": "Cutthroat Politico",
+            "limited": 1,
+            "cost": 75,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "deltasquadronpilot": {
+            "name": "Delta Squadron Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 67,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "onyxsquadronace": {
+            "name": "Onyx Squadron Ace",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 71,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "rexlerbrath": {
+            "name": "Rexler Brath",
+            "subtitle": "Onyx Leader",
+            "limited": 1,
+            "cost": 77,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "vultskerris": {
+            "name": "Vult Skerris",
+            "subtitle": "Arrogant Ace",
+            "limited": 1,
+            "cost": 76,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "darthvader-tieddefender": {
+            "name": "Darth Vader",
+            "subtitle": "Dark Lord of the Sith",
+            "limited": 1,
+            "cost": 115,
+            "slots": [
+                "Force Power",
+                "Cannon",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "Dark Side",
+                "Sith",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "captaindobbs": {
+            "name": "Captain Dobbs",
+            "subtitle": "Reliable Replacement",
+            "limited": 1,
+            "cost": 70,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "captainyorr-battleoverendor": {
+            "name": "Captain Yorr",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 85,
+            "slots": [],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "noescape-battleoverendor",
+                "predator",
+                "ioncannon",
+                "computerassistedhandling-battleoverendor"
+            ]
+        },
+        "captainyorr-battleoverendor-lsl": {
+            "name": "Captain Yorr",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 72,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Missile"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "coloneljendon-battleoverendor": {
+            "name": "Colonel Jendon",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 87,
+            "slots": [],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "noescape-battleoverendor",
+                "pushthelimit-battleoverendor",
+                "protoncannons",
+                "computerassistedhandling-battleoverendor"
+            ]
+        },
+        "coloneljendon-battleoverendor-lsl": {
+            "name": "Colonel Jendon",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 80,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Missile"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "TIE/ag Aggressor": {
+        "doubleedge": {
+            "name": "“Double Edge”",
+            "subtitle": "Contingency Planner",
+            "limited": 1,
+            "cost": 27,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Turret",
+                "Missile",
+                "Missile",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lieutenantkestal": {
+            "name": "Lieutenant Kestal",
+            "subtitle": "Innate Deadeye",
+            "limited": 1,
+            "cost": 28,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Turret",
+                "Missile",
+                "Missile",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "onyxsquadronscout": {
+            "name": "Onyx Squadron Scout",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 27,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Turret",
+                "Missile",
+                "Missile",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sienarspecialist": {
+            "name": "Sienar Specialist",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 26,
+            "slots": [
+                "Sensor",
+                "Turret",
+                "Missile",
+                "Missile",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "TIE/ca Punisher": {
+        "deathrain": {
+            "name": "“Deathrain”",
+            "subtitle": "Dexterous Bombardier",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Sensor",
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "redline": {
+            "name": "“Redline”",
+            "subtitle": "Adrenaline Junkie",
+            "limited": 1,
+            "cost": 50,
+            "slots": [
+                "Sensor",
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "cutlasssquadronpilot": {
+            "name": "Cutlass Squadron Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 34,
+            "slots": [
+                "Sensor",
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "TIE/ln Fighter": {
+        "howlrunner": {
+            "name": "“Howlrunner”",
+            "subtitle": "Obsidian Leader",
+            "limited": 1,
+            "cost": 39,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "maulermithel": {
+            "name": "“Mauler” Mithel",
+            "subtitle": "Black Two",
+            "limited": 1,
+            "cost": 29,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "nightbeast": {
+            "name": "“Night Beast”",
+            "subtitle": "Obsidian Two",
+            "limited": 1,
+            "cost": 22,
+            "slots": [
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "scourgeskutu": {
+            "name": "“Scourge” Skutu",
+            "subtitle": "Seasoned Veteran",
+            "limited": 1,
+            "cost": 28,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "wampa": {
+            "name": "“Wampa”",
+            "subtitle": "Black Eleven",
+            "limited": 1,
+            "cost": 27,
+            "slots": [
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "academypilot": {
+            "name": "Academy Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 22,
+            "slots": [
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "blacksquadronace": {
+            "name": "Black Squadron Ace",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 24,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "delmeeko": {
+            "name": "Del Meeko",
+            "subtitle": "Inferno Three",
+            "limited": 1,
+            "cost": 27,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "gideonhask": {
+            "name": "Gideon Hask",
+            "subtitle": "Inferno Two",
+            "limited": 1,
+            "cost": 27,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "idenversio": {
+            "name": "Iden Versio",
+            "subtitle": "Inferno Leader",
+            "limited": 1,
+            "cost": 42,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "obsidiansquadronpilot": {
+            "name": "Obsidian Squadron Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 23,
+            "slots": [
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "seynmarana": {
+            "name": "Seyn Marana",
+            "subtitle": "Inferno Four",
+            "limited": 1,
+            "cost": 27,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "valenrudor": {
+            "name": "Valen Rudor",
+            "subtitle": "Braggadocious Baron",
+            "limited": 1,
+            "cost": 23,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "isbjingoist": {
+            "name": "ISB Jingoist",
+            "subtitle": "Heartless Enforcer",
+            "limited": 2,
+            "cost": 28,
+            "slots": [
+                "Talent",
+                "Illicit",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "moffgideon": {
+            "name": "Moff Gideon",
+            "subtitle": "Ruthless Remnant Leader",
+            "limited": 1,
+            "cost": 31,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "backstabber-battleofyavin": {
+            "name": "“Backstabber”",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 38,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "crackshot",
+                "disciplined",
+                "afterburners"
+            ]
+        },
+        "backstabber-battleofyavin-lsl": {
+            "name": "“Backstabber”",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 36,
+            "slots": [
+                "Talent"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "darkcurse-battleofyavin": {
+            "name": "“Dark Curse”",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 37,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "ruthless",
+                "precisionionengines"
+            ]
+        },
+        "darkcurse-battleofyavin-lsl": {
+            "name": "“Dark Curse”",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 34,
+            "slots": [
+                "Talent"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "maulermithel-battleofyavin": {
+            "name": "“Mauler” Mithel",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 37,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "predator",
+                "afterburners"
+            ]
+        },
+        "maulermithel-battleofyavin-lsl": {
+            "name": "“Mauler” Mithel",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 36,
+            "slots": [
+                "Talent"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "wampa-battleofyavin": {
+            "name": "“Wampa”",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 39,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "elusive",
+                "vengeful-battleofyavin"
+            ]
+        },
+        "wampa-battleofyavin-lsl": {
+            "name": "“Wampa”",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 31,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "magnatolvan": {
+            "name": "Magna Tolvan",
+            "subtitle": "Cold Tyrant",
+            "limited": 1,
+            "cost": 24,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "yricaquell": {
+            "name": "Yrica Quell",
+            "subtitle": "Consumed by Duty",
+            "limited": 1,
+            "cost": 24,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "idenversio-swz105": {
+            "name": "Iden Versio",
+            "subtitle": "Inferno Leader",
+            "limited": 1,
+            "cost": 45,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "disciplined",
+                "elusive"
+            ]
+        },
+        "nightbeast-swz105": {
+            "name": "“Night Beast”",
+            "subtitle": "Obsidian Two",
+            "limited": 1,
+            "cost": 26,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "disciplined",
+                "predator"
+            ]
+        },
+        "valenrudor-swz105": {
+            "name": "Valen Rudor",
+            "subtitle": "Braggadocious Baron",
+            "limited": 1,
+            "cost": 27,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "disciplined",
+                "precisionionengines"
+            ]
+        },
+        "lieutenanthebsly-battleoverendor": {
+            "name": "Lieutenant Hebsly",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 51,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "collected-battleoverendor",
+                "elusive",
+                "noescape-battleoverendor"
+            ]
+        },
+        "lieutenanthebsly-battleoverendor-lsl": {
+            "name": "Lieutenant Hebsly",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Talent"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "scythe6-battleoverendor": {
+            "name": "Scythe 6",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 53,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "noescape-battleoverendor",
+                "predator",
+                "ionmaneuveringjet-battleoverendor",
+                "targetingmatrix-battleoverendor"
+            ]
+        },
+        "scythe6-battleoverendor-lsl": {
+            "name": "Scythe 6",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 42,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "majormianda-battleoverendor": {
+            "name": "Major Mianda",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 48,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "noescape-battleoverendor",
+                "ruthless",
+                "swarmtactics"
+            ]
+        },
+        "majormianda-battleoverendor-lsl": {
+            "name": "Major Mianda",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Talent"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "TIE/ph Phantom": {
+        "echo": {
+            "name": "“Echo”",
+            "subtitle": "Slippery Trickster",
+            "limited": 1,
+            "cost": 51,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "whisper": {
+            "name": "“Whisper”",
+            "subtitle": "Soft-Spoken Slayer",
+            "limited": 1,
+            "cost": 60,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "imdaartestpilot": {
+            "name": "Imdaar Test Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 43,
+            "slots": [
+                "Sensor",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sigmasquadronace": {
+            "name": "Sigma Squadron Ace",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 48,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "captainsaxton-wat1": {
+            "name": "Captain Saxton",
+            "subtitle": "Unpredictable Menace",
+            "limited": 1,
+            "cost": 45,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "whisper-pnp": {
+            "name": "“Whisper”",
+            "subtitle": "Unseen Assailant",
+            "limited": 1,
+            "cost": 5,
+            "slots": [],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "No",
+            "standardLoadout": [
+                "withoutatrace-tiephphantom",
+                "relaysystem-tiephphantom",
+                "stygiumreserve-tiephphantom"
+            ]
+        },
+        "whisper-pnp-ls": {
+            "name": "“Whisper”",
+            "subtitle": "Unseen Assailant",
+            "limited": 1,
+            "cost": 57,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "echo-pnp": {
+            "name": "“Echo”",
+            "subtitle": "Copycat",
+            "limited": 1,
+            "cost": 5,
+            "slots": [],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "No",
+            "standardLoadout": [
+                "silenthunter-tiephphantom",
+                "stealthgambit-tiephphantom",
+                "manualailerons-tiephphantom"
+            ]
+        },
+        "echo-pnp-lsl": {
+            "name": "“Echo”",
+            "subtitle": "Copycat",
+            "limited": 1,
+            "cost": 48,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "TIE/sa Bomber": {
+        "deathfire": {
+            "name": "“Deathfire”",
+            "subtitle": "Unflinching Diehard",
+            "limited": 1,
+            "cost": 29,
+            "slots": [
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "captainjonus": {
+            "name": "Captain Jonus",
+            "subtitle": "Disciplined Instructor",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "gammasquadronace": {
+            "name": "Gamma Squadron Ace",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 29,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "majorrhymer": {
+            "name": "Major Rhymer",
+            "subtitle": "Scimitar Leader",
+            "limited": 1,
+            "cost": 35,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "scimitarsquadronpilot": {
+            "name": "Scimitar Squadron Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 27,
+            "slots": [
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "tomaxbren": {
+            "name": "Tomax Bren",
+            "subtitle": "Brash Maverick",
+            "limited": 1,
+            "cost": 34,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "captainjonus-swz105": {
+            "name": "Captain Jonus",
+            "subtitle": "Disciplined Instructor",
+            "limited": 1,
+            "cost": 54,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "feedbackping",
+                "plasmatorpedoes",
+                "protonbombs"
+            ]
+        },
+        "tomaxbren-swz105": {
+            "name": "Tomax Bren",
+            "subtitle": "Brash Maverick",
+            "limited": 1,
+            "cost": 48,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "elusive",
+                "barragerockets",
+                "proximitymines"
+            ]
+        },
+        "deathfire-swz98": {
+            "name": "“Deathfire”",
+            "subtitle": "Obstinate Bombardier",
+            "limited": 1,
+            "cost": 45,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "swiftapproach-swz98",
+                "connernets",
+                "protonbombs"
+            ]
+        },
+        "deathfire-swz98-lsl": {
+            "name": "“Deathfire”",
+            "subtitle": "Obstinate Bombardier",
+            "limited": 1,
+            "cost": 33,
+            "slots": [
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "captainjonus-swz98": {
+            "name": "Captain Jonus",
+            "subtitle": "Top Cover",
+            "limited": 1,
+            "cost": 51,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "topcover-swz98",
+                "barragerockets",
+                "protonbombs"
+            ]
+        },
+        "captainjonus-swz98-lsl": {
+            "name": "Captain Jonus",
+            "subtitle": "Top Cover",
+            "limited": 1,
+            "cost": 36,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "tomaxbren-swz98": {
+            "name": "Tomax Bren",
+            "subtitle": "Scimitar Veteran",
+            "limited": 1,
+            "cost": 53,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "truegrit-swz98",
+                "plasmatorpedoes",
+                "ionbombs"
+            ]
+        },
+        "tomaxbren-swz98-lsl": {
+            "name": "Tomax Bren",
+            "subtitle": "Scimitar Veteran",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "majorrhymer-swz98": {
+            "name": "Major Rhymer",
+            "subtitle": "Precision Destruction",
+            "limited": 1,
+            "cost": 41,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "advprotontorpedoes",
+                "automatedloaders-swz98",
+                "afterburners"
+            ]
+        },
+        "majorrhymer-swz98-lsl": {
+            "name": "Major Rhymer",
+            "subtitle": "Precision Destruction",
+            "limited": 1,
+            "cost": 33,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "scimitar1-battleoverendor": {
+            "name": "Scimitar 1",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 56,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "marksmanship",
+                "noescape-battleoverendor",
+                "protontorpedoes",
+                "ionbombs"
+            ]
+        },
+        "scimitar1-battleoverendor-lsl": {
+            "name": "Scimitar 1",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 36,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "scimitar3-battleoverendor": {
+            "name": "Scimitar 3",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 57,
+            "slots": [],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "noescape-battleoverendor",
+                "partinggift-battleoverendor",
+                "protontorpedoes",
+                "protonbombs"
+            ]
+        },
+        "scimitar3-battleoverendor-lsl": {
+            "name": "Scimitar 3",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 34,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "TIE/sk Striker": {
+        "countdown": {
+            "name": "“Countdown”",
+            "subtitle": "Death Defier",
+            "limited": 1,
+            "cost": 39,
+            "slots": [
+                "Talent",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "duchess": {
+            "name": "“Duchess”",
+            "subtitle": "Urbane Ace",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Talent",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "puresabacc": {
+            "name": "“Pure Sabacc”",
+            "subtitle": "Confident Gambler",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "blacksquadronscout": {
+            "name": "Black Squadron Scout",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 34,
+            "slots": [
+                "Talent",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "planetarysentinel": {
+            "name": "Planetary Sentinel",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 32,
+            "slots": [
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "vagabond": {
+            "name": "“Vagabond”",
+            "subtitle": "Destitute Demolitionist",
+            "limited": 1,
+            "cost": 32,
+            "slots": [
+                "Talent",
+                "Gunner",
+                "Device",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "VT-49 Decimator": {
+        "captainoicunn": {
+            "name": "Captain Oicunn",
+            "subtitle": "Inspired Tactician",
+            "limited": 1,
+            "cost": 68,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Crew",
+                "Device",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "patrolleader": {
+            "name": "Patrol Leader",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 67,
+            "slots": [
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Crew",
+                "Device",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "rearadmiralchiraneau": {
+            "name": "Rear Admiral Chiraneau",
+            "subtitle": "Advisor to Admiral Piett",
+            "limited": 1,
+            "cost": 76,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Crew",
+                "Device",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "mornakee": {
+            "name": "Morna Kee",
+            "subtitle": "Determined Attaché",
+            "limited": 1,
+            "cost": 69,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Crew",
+                "Gunner",
+                "Device",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "TIE/rb Heavy": {
+        "caridaacademycadet": {
+            "name": "Carida Academy Cadet",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 32,
+            "slots": [
+                "Cannon",
+                "Cannon",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "onyxsquadronsentry": {
+            "name": "Onyx Squadron Sentry",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 35,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Cannon",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "rampage": {
+            "name": "“Rampage”",
+            "subtitle": "Implacable Pursuer",
+            "limited": 1,
+            "cost": 36,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Cannon",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lyttandree": {
+            "name": "Lyttan Dree",
+            "subtitle": "Onyx 2",
+            "limited": 1,
+            "cost": 36,
+            "slots": [
+                "Cannon",
+                "Cannon",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "flightleaderubbel": {
+            "name": "Flight Leader Ubbel",
+            "subtitle": "Onyx Leader",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Cannon",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    }
+}

--- a/X2PO/dec2025/galacticrepublic.json
+++ b/X2PO/dec2025/galacticrepublic.json
@@ -1,0 +1,1786 @@
+{
+    "ARC-170 Starfighter": {
+        "sinker": {
+            "name": "“Sinker”",
+            "subtitle": "Wolfpack Veteran",
+            "limited": 1,
+            "cost": 51,
+            "slots": [
+                "Torpedo",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "jag": {
+            "name": "“Jag”",
+            "subtitle": "CT-55/11-9009",
+            "limited": 1,
+            "cost": 47,
+            "slots": [
+                "Torpedo",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "oddball-arc170starfighter": {
+            "name": "“Odd Ball”",
+            "subtitle": "CC-2237",
+            "limited": 1,
+            "cost": 48,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "wolffe": {
+            "name": "“Wolffe”",
+            "subtitle": "CC-3636",
+            "limited": 1,
+            "cost": 49,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "104thbattalionpilot": {
+            "name": "104th Battalion Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 42,
+            "slots": [
+                "Torpedo",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "squadsevenveteran": {
+            "name": "Squad Seven Veteran",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 44,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "oddball-siegeofcoruscant": {
+            "name": "“Odd Ball”",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 56,
+            "slots": [],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "selfless",
+                "veterantailgunner",
+                "r4pastromech"
+            ]
+        },
+        "oddball-siegeofcoruscant-lsl": {
+            "name": "“Odd Ball”",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 50,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Crew",
+                "Astromech",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "wolffe-siegeofcoruscant": {
+            "name": "“Wolffe”",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 56,
+            "slots": [],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "wolfpack-siegeofcoruscant",
+                "veterantailgunner",
+                "q7astromech"
+            ]
+        },
+        "wolffe-siegeofcoruscant-lsl": {
+            "name": "“Wolffe”",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 50,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "jag-siegeofcoruscant": {
+            "name": "“Jag”",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 51,
+            "slots": [],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "veterantailgunner",
+                "r4pastromech",
+                "synchronizedconsole"
+            ]
+        },
+        "jag-siegeofcoruscant-lsl": {
+            "name": "“Jag”",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 47,
+            "slots": [
+                "Torpedo",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Delta-7 Aethersprite": {
+        "jediknight": {
+            "name": "Jedi Knight",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 35,
+            "slots": [
+                "Astromech",
+                "Modification",
+                "Force Power",
+                "Configuration"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "obiwankenobi": {
+            "name": "Obi-Wan Kenobi",
+            "subtitle": "Guardian of the Republic",
+            "limited": 1,
+            "cost": 48,
+            "slots": [
+                "Astromech",
+                "Modification",
+                "Force Power",
+                "Configuration"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "plokoon": {
+            "name": "Plo Koon",
+            "subtitle": "Serene Mentor",
+            "limited": 1,
+            "cost": 45,
+            "slots": [
+                "Astromech",
+                "Modification",
+                "Force Power",
+                "Configuration"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "saeseetiin": {
+            "name": "Saesee Tiin",
+            "subtitle": "Prophetic Pilot",
+            "limited": 1,
+            "cost": 39,
+            "slots": [
+                "Astromech",
+                "Modification",
+                "Force Power",
+                "Configuration"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "macewindu": {
+            "name": "Mace Windu",
+            "subtitle": "Harsh Traditionalist",
+            "limited": 1,
+            "cost": 42,
+            "slots": [
+                "Astromech",
+                "Modification",
+                "Force Power",
+                "Configuration"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "anakinskywalker": {
+            "name": "Anakin Skywalker",
+            "subtitle": "Hero of the Republic",
+            "limited": 1,
+            "cost": 55,
+            "slots": [
+                "Astromech",
+                "Modification",
+                "Force Power",
+                "Configuration"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ahsokatano": {
+            "name": "Ahsoka Tano",
+            "subtitle": "“Snips”",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Astromech",
+                "Modification",
+                "Force Power",
+                "Configuration"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "barrissoffee": {
+            "name": "Barriss Offee",
+            "subtitle": "Conflicted Padawan",
+            "limited": 1,
+            "cost": 35,
+            "slots": [
+                "Astromech",
+                "Modification",
+                "Force Power",
+                "Configuration"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "luminaraunduli": {
+            "name": "Luminara Unduli",
+            "subtitle": "Wise Protector",
+            "limited": 1,
+            "cost": 39,
+            "slots": [
+                "Astromech",
+                "Modification",
+                "Force Power",
+                "Configuration"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "adigallia": {
+            "name": "Adi Gallia",
+            "subtitle": "Shooting Star",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Astromech",
+                "Modification",
+                "Force Power",
+                "Configuration"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "depabillaba-wat1": {
+            "name": "Depa Billaba",
+            "subtitle": "Hazard Three",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Astromech",
+                "Modification",
+                "Force Power",
+                "Configuration"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "CR90 Corellian Corvette": {
+        "republicjudiciary": {
+            "name": "Republic Judiciary",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 125,
+            "slots": [
+                "Command",
+                "Hardpoint",
+                "Hardpoint",
+                "Crew",
+                "Crew",
+                "Gunner",
+                "Team",
+                "Team",
+                "Cargo"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "Yes"
+        }
+    },
+    "V-19 Torrent Starfighter": {
+        "kickback": {
+            "name": "“Kickback”",
+            "subtitle": "Blue Four",
+            "limited": 1,
+            "cost": 27,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "oddball": {
+            "name": "“Odd Ball”",
+            "subtitle": "CC-2237",
+            "limited": 1,
+            "cost": 29,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "swoop": {
+            "name": "“Swoop”",
+            "subtitle": "Blue Six",
+            "limited": 1,
+            "cost": 26,
+            "slots": [
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "axe": {
+            "name": "“Axe”",
+            "subtitle": "Blue Two",
+            "limited": 1,
+            "cost": 26,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "tucker": {
+            "name": "“Tucker”",
+            "subtitle": "Blue Five",
+            "limited": 1,
+            "cost": 25,
+            "slots": [
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "bluesquadronprotector": {
+            "name": "Blue Squadron Protector",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 26,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "goldsquadrontrooper": {
+            "name": "Gold Squadron Trooper",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 25,
+            "slots": [
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "kickback-siegeofcoruscant": {
+            "name": "“Kickback”",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 41,
+            "slots": [],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "diamondboronmissiles",
+                "munitionsfailsafe"
+            ]
+        },
+        "kickback-siegeofcoruscant-lsl": {
+            "name": "“Kickback”",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 32,
+            "slots": [
+                "Talent",
+                "Missile"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "axe-siegeofcoruscant": {
+            "name": "“Axe”",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 40,
+            "slots": [],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "deadeyeshot",
+                "barragerockets"
+            ]
+        },
+        "axe-siegeofcoruscant-lsl": {
+            "name": "“Axe”",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Missile"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "slammer": {
+            "name": "“Slammer”",
+            "subtitle": "Blue Three",
+            "limited": 1,
+            "cost": 34,
+            "slots": [
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Naboo Royal N-1 Starfighter": {
+        "anakinskywalker-nabooroyaln1starfighter": {
+            "name": "Anakin Skywalker",
+            "subtitle": "Hero of Naboo",
+            "limited": 1,
+            "cost": 40,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Torpedo",
+                "Astromech"
+            ],
+            "keywords": [
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ricolie": {
+            "name": "Ric Olié",
+            "subtitle": "Bravo Leader",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Sensor",
+                "Torpedo",
+                "Astromech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "padmeamidala": {
+            "name": "Padmé Amidala",
+            "subtitle": "Aggressive Negotiator",
+            "limited": 1,
+            "cost": 35,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Sensor",
+                "Torpedo",
+                "Astromech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dineeellberger": {
+            "name": "Dineé Ellberger",
+            "subtitle": "Bravo Five",
+            "limited": 1,
+            "cost": 29,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Sensor",
+                "Torpedo",
+                "Astromech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "bravoflightofficer": {
+            "name": "Bravo Flight Officer",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 28,
+            "slots": [
+                "Sensor",
+                "Torpedo",
+                "Astromech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "naboohandmaiden": {
+            "name": "Naboo Handmaiden",
+            "subtitle": "Regal Ruse",
+            "limited": 2,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Torpedo",
+                "Astromech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "gavynsykes": {
+            "name": "Gavyn Sykes",
+            "subtitle": "Bravo Three",
+            "limited": 1,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Sensor",
+                "Torpedo",
+                "Astromech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "rhysdallows-wat1": {
+            "name": "Rhys Dallows",
+            "subtitle": "Echo Five",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Illicit",
+                "Sensor",
+                "Torpedo",
+                "Astromech"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "essaratill-wat1": {
+            "name": "Essara Till",
+            "subtitle": "Bravo Seven",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Sensor",
+                "Torpedo",
+                "Astromech"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "BTL-B Y-wing": {
+        "shadowsquadronveteran": {
+            "name": "Shadow Squadron Veteran",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 31,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone",
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "anakinskywalker-btlbywing": {
+            "name": "Anakin Skywalker",
+            "subtitle": "Hero of the Republic",
+            "limited": 1,
+            "cost": 48,
+            "slots": [
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Gunner",
+                "Force Power"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side",
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "r2d2": {
+            "name": "R2-D2",
+            "subtitle": "Bucket of Bolts",
+            "limited": 1,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Torpedo",
+                "Crew",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "Droid",
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "oddball-btlbywing": {
+            "name": "“Odd Ball”",
+            "subtitle": "CC-2237",
+            "limited": 1,
+            "cost": 37,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone",
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "matchstick": {
+            "name": "“Matchstick”",
+            "subtitle": "Shadow Two",
+            "limited": 1,
+            "cost": 39,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone",
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "broadside": {
+            "name": "“Broadside”",
+            "subtitle": "Shadow Three",
+            "limited": 1,
+            "cost": 35,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone",
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "goji": {
+            "name": "“Goji”",
+            "subtitle": "Payload Specialist",
+            "limited": 1,
+            "cost": 29,
+            "slots": [
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone",
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "redsquadronbomber": {
+            "name": "Red Squadron Bomber",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 30,
+            "slots": [
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone",
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Eta-2 Actis": {
+        "anakinskywalker-eta2actis": {
+            "name": "Anakin Skywalker",
+            "subtitle": "Hero of Coruscant",
+            "limited": 1,
+            "cost": 51,
+            "slots": [
+                "Talent",
+                "Force Power",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [
+                "Dark Side",
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "obiwankenobi-eta2actis": {
+            "name": "Obi-Wan Kenobi",
+            "subtitle": "Guardian of Democracy",
+            "limited": 1,
+            "cost": 48,
+            "slots": [
+                "Talent",
+                "Force Power",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "aaylasecura": {
+            "name": "Aayla Secura",
+            "subtitle": "Confident Warrior",
+            "limited": 1,
+            "cost": 47,
+            "slots": [
+                "Talent",
+                "Force Power",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "shaakti": {
+            "name": "Shaak Ti",
+            "subtitle": "Compassionate Mentor",
+            "limited": 1,
+            "cost": 45,
+            "slots": [
+                "Talent",
+                "Force Power",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "jedigeneral": {
+            "name": "Jedi General",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 41,
+            "slots": [
+                "Force Power",
+                "Cannon",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "yoda": {
+            "name": "Yoda",
+            "subtitle": "Grand Master",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Force Power",
+                "Force Power",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "anakinskywalker-siegeofcoruscant": {
+            "name": "Anakin Skywalker",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 66,
+            "slots": [],
+            "keywords": [
+                "Dark Side",
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "malice",
+                "ancillaryionweapons-siegeofcoruscant",
+                "r2d2-republic"
+            ]
+        },
+        "anakinskywalker-siegeofcoruscant-lsl": {
+            "name": "Anakin Skywalker",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 51,
+            "slots": [
+                "Talent",
+                "Force Power",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [
+                "Dark Side",
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "obiwankenobi-siegeofcoruscant": {
+            "name": "Obi-Wan Kenobi",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 52,
+            "slots": [],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "patience",
+                "ancillaryionweapons-siegeofcoruscant",
+                "r4p17-siegeofcoruscant"
+            ]
+        },
+        "obiwankenobi-siegeofcoruscant-lsl": {
+            "name": "Obi-Wan Kenobi",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 47,
+            "slots": [
+                "Talent",
+                "Force Power",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "shaakti-siegeofcoruscant": {
+            "name": "Shaak Ti",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 49,
+            "slots": [],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "marksmanship",
+                "brilliantevasion",
+                "ancillaryionweapons-siegeofcoruscant",
+                "r4pastromech"
+            ]
+        },
+        "shaakti-siegeofcoruscant-lsl": {
+            "name": "Shaak Ti",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 42,
+            "slots": [
+                "Talent",
+                "Force Power",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "kitfisto": {
+            "name": "Kit Fisto",
+            "subtitle": "Enthusiastic Exemplar",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Force Power",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Gauntlet Fighter": {
+        "bokatankryze": {
+            "name": "Bo-Katan Kryze",
+            "subtitle": "Nite Owl Commander",
+            "limited": 1,
+            "cost": 56,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Gunner",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Configuration",
+                "Title"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "niteowlliberator": {
+            "name": "Nite Owl Liberator",
+            "subtitle": "Resolute Warrior",
+            "limited": 1,
+            "cost": 54,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Gunner",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Configuration",
+                "Title"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "LAAT/i Gunship": {
+        "hawk": {
+            "name": "“Hawk”",
+            "subtitle": "Valkyrie 2929",
+            "limited": 1,
+            "cost": 48,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "hound": {
+            "name": "“Hound”",
+            "subtitle": "Vigilant Tracker",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "warthog": {
+            "name": "“Warthog”",
+            "subtitle": "Veteran of Kadavo",
+            "limited": 1,
+            "cost": 51,
+            "slots": [
+                "Missile",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "212thbattalionpilot": {
+            "name": "212th Battalion Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 45,
+            "slots": [
+                "Missile",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sicko": {
+            "name": "“Sicko”",
+            "subtitle": "CT-1127/549",
+            "limited": 1,
+            "cost": 47,
+            "slots": [
+                "Missile",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner",
+                "Gunner"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Nimbus-class V-wing": {
+        "wilhufftarkin": {
+            "name": "Wilhuff Tarkin",
+            "subtitle": "Aspiring Admiral",
+            "limited": 1,
+            "cost": 29,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "oddball-nimbusclassvwing": {
+            "name": "“Odd Ball”",
+            "subtitle": "CC-2237",
+            "limited": 1,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Clone",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "contrail": {
+            "name": "“Contrail”",
+            "subtitle": "CT-4981",
+            "limited": 1,
+            "cost": 31,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Clone",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "klick": {
+            "name": "“Klick”",
+            "subtitle": "GC-1000",
+            "limited": 1,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Clone",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "shadowsquadronescort": {
+            "name": "Shadow Squadron Escort",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 28,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Clone",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "loyalistvolunteer": {
+            "name": "Loyalist Volunteer",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 26,
+            "slots": [
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "klick-siegeofcoruscant": {
+            "name": "“Klick”",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 41,
+            "slots": [],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "r3astromech",
+                "precisionionengines",
+                "alpha3eesk"
+            ]
+        },
+        "klick-siegeofcoruscant-lsl": {
+            "name": "“Klick”",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 36,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Clone",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "contrail-siegeofcoruscant": {
+            "name": "“Contrail”",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 46,
+            "slots": [],
+            "keywords": [
+                "Clone",
+                "TIE"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "ionlimiteroverride",
+                "preciseastromech-battleofyavin",
+                "ionbombs",
+                "alpha3bbesh"
+            ]
+        },
+        "contrail-siegeofcoruscant-lsl": {
+            "name": "“Contrail”",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 32,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Clone",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Syliure-class Hyperspace Ring": {
+        "transgalmegcontrollink": {
+            "name": "TransGalMeg Control Link",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 4,
+            "slots": [
+                "Hyperdrive"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "Yes"
+        }
+    },
+    "Clone Z-95 Headhunter": {
+        "killer": {
+            "name": "“Killer”",
+            "subtitle": "Dependable Closer",
+            "limited": 1,
+            "cost": 25,
+            "slots": [
+                "Sensor",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "drift": {
+            "name": "“Drift”",
+            "subtitle": "CT-1020",
+            "limited": 1,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "boost": {
+            "name": "“Boost”",
+            "subtitle": "CT-4860",
+            "limited": 1,
+            "cost": 25,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "stub": {
+            "name": "“Stub”",
+            "subtitle": "Scrappy Flier",
+            "limited": 1,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "knack": {
+            "name": "“Knack”",
+            "subtitle": "Incautious Instructor",
+            "limited": 1,
+            "cost": 26,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Sensor",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "hawk-clonez95headhunter": {
+            "name": "“Hawk”",
+            "subtitle": "Valkyrie 2929",
+            "limited": 1,
+            "cost": 25,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Sensor",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "7thskycorpspilot": {
+            "name": "7th Sky Corps Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 22,
+            "slots": [
+                "Sensor",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "reapersquadronscout": {
+            "name": "Reaper Squadron Scout",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 24,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "slider": {
+            "name": "“Slider”",
+            "subtitle": "Evasive Aviator",
+            "limited": 1,
+            "cost": 26,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "warthog-clonez95headhunter": {
+            "name": "“Warthog”",
+            "subtitle": "Veteran of Kadavo",
+            "limited": 1,
+            "cost": 29,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Modification"
+            ],
+            "keywords": [
+                "Clone"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    }
+}

--- a/X2PO/dec2025/rebelalliance.json
+++ b/X2PO/dec2025/rebelalliance.json
@@ -1,0 +1,3159 @@
+{
+    "A/SF-01 B-wing": {
+        "bladesquadronveteran": {
+            "name": "Blade Squadron Veteran",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Modification",
+                "Title",
+                "Configuration"
+            ],
+            "keywords": [
+                "B-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "bluesquadronpilot": {
+            "name": "Blue Squadron Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 39,
+            "slots": [
+                "Sensor",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Modification",
+                "Title",
+                "Configuration"
+            ],
+            "keywords": [
+                "B-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "braylenstramm": {
+            "name": "Braylen Stramm",
+            "subtitle": "Blade Leader",
+            "limited": 1,
+            "cost": 52,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Modification",
+                "Title",
+                "Configuration"
+            ],
+            "keywords": [
+                "B-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "tennumb": {
+            "name": "Ten Numb",
+            "subtitle": "Blue Five",
+            "limited": 1,
+            "cost": 49,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Modification",
+                "Title",
+                "Configuration"
+            ],
+            "keywords": [
+                "B-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ginamoonsong": {
+            "name": "Gina Moonsong",
+            "subtitle": "Insubordinate Ace",
+            "limited": 1,
+            "cost": 47,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Modification",
+                "Title",
+                "Configuration"
+            ],
+            "keywords": [
+                "B-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "herasyndulla-asf01bwing": {
+            "name": "Hera Syndulla",
+            "subtitle": "Phoenix Leader",
+            "limited": 1,
+            "cost": 50,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Modification",
+                "Title",
+                "Configuration"
+            ],
+            "keywords": [
+                "B-wing",
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "netrempollard": {
+            "name": "Netrem Pollard",
+            "subtitle": "Dagger Leader",
+            "limited": 1,
+            "cost": 42,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Modification",
+                "Title",
+                "Configuration"
+            ],
+            "keywords": [
+                "B-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "adonfox-battleoverendor": {
+            "name": "Adon Fox",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 65,
+            "slots": [],
+            "keywords": [
+                "B-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "itsatrap-battleoverendor",
+                "partinggift-battleoverendor",
+                "protonrockets",
+                "protonbombs"
+            ]
+        },
+        "adonfox-battleoverendor-lsl": {
+            "name": "Adon Fox",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Sensor",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Modification",
+                "Title",
+                "Configuration"
+            ],
+            "keywords": [
+                "B-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ginamoonsong-battleoverendor": {
+            "name": "Gina Moonsong",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 80,
+            "slots": [],
+            "keywords": [
+                "B-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "itsatrap-battleoverendor",
+                "juke",
+                "protontorpedoes",
+                "ionbombs"
+            ]
+        },
+        "ginamoonsong-battleoverendor-lsl": {
+            "name": "Gina Moonsong",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 55,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Title",
+                "Configuration"
+            ],
+            "keywords": [
+                "B-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "braylenstramm-battleoverendor": {
+            "name": "Braylen Stramm",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 68,
+            "slots": [],
+            "keywords": [
+                "B-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "itsatrap-battleoverendor",
+                "homingmissiles",
+                "protonbombs",
+                "delayedfuses"
+            ]
+        },
+        "braylenstramm-battleoverendor-lsl": {
+            "name": "Braylen Stramm",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 53,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Title",
+                "Configuration"
+            ],
+            "keywords": [
+                "B-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "neradantels-wat1": {
+            "name": "Nera Dantels",
+            "subtitle": "Blue Dagger",
+            "limited": 1,
+            "cost": 45,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Modification",
+                "Title",
+                "Configuration"
+            ],
+            "keywords": [
+                "B-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "ARC-170 Starfighter": {
+        "garvendreis": {
+            "name": "Garven Dreis",
+            "subtitle": "Red Leader",
+            "limited": 1,
+            "cost": 50,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ibtisam": {
+            "name": "Ibtisam",
+            "subtitle": "Survivor of Endor",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "norrawexley": {
+            "name": "Norra Wexley",
+            "subtitle": "Gold Nine",
+            "limited": 1,
+            "cost": 53,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sharabey": {
+            "name": "Shara Bey",
+            "subtitle": "Green Four",
+            "limited": 1,
+            "cost": 49,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Attack Shuttle": {
+        "zeborrelios": {
+            "name": "“Zeb” Orrelios",
+            "subtitle": "Spectre-4",
+            "limited": 1,
+            "cost": 33,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Crew",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ezrabridger": {
+            "name": "Ezra Bridger",
+            "subtitle": "Spectre-6",
+            "limited": 1,
+            "cost": 40,
+            "slots": [
+                "Turret",
+                "Crew",
+                "Modification",
+                "Title",
+                "Force Power"
+            ],
+            "keywords": [
+                "Light Side",
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "herasyndulla": {
+            "name": "Hera Syndulla",
+            "subtitle": "Spectre-2",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Crew",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sabinewren": {
+            "name": "Sabine Wren",
+            "subtitle": "Spectre-5",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Crew",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Mandalorian",
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Auzituck Gunship": {
+        "kashyyykdefender": {
+            "name": "Kashyyyk Defender",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 44,
+            "slots": [
+                "Crew",
+                "Crew",
+                "Modification"
+            ],
+            "keywords": [
+                "Wookiee"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lowhhrick": {
+            "name": "Lowhhrick",
+            "subtitle": "Escaped Gladiator",
+            "limited": 1,
+            "cost": 49,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Crew",
+                "Modification"
+            ],
+            "keywords": [
+                "Wookiee"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "wullffwarro": {
+            "name": "Wullffwarro",
+            "subtitle": "Wookiee Chief",
+            "limited": 1,
+            "cost": 54,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Crew",
+                "Modification"
+            ],
+            "keywords": [
+                "Wookiee"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "tarfful-wat1": {
+            "name": "Tarfful",
+            "subtitle": "Leader of Kachirho",
+            "limited": 1,
+            "cost": 59,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Crew",
+                "Modification"
+            ],
+            "keywords": [
+                "Wookiee"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "BTL-A4 Y-wing": {
+        "dutchvander": {
+            "name": "“Dutch” Vander",
+            "subtitle": "Gold Leader",
+            "limited": 1,
+            "cost": 40,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Missile"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "evaanverlaine": {
+            "name": "Evaan Verlaine",
+            "subtitle": "Gold Three",
+            "limited": 1,
+            "cost": 32,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Missile"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "goldsquadronveteran": {
+            "name": "Gold Squadron Veteran",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 31,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Missile"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "graysquadronbomber": {
+            "name": "Gray Squadron Bomber",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 29,
+            "slots": [
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Missile"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "hortonsalm": {
+            "name": "Horton Salm",
+            "subtitle": "Gray Leader",
+            "limited": 1,
+            "cost": 36,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Missile"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "norrawexley-btla4ywing": {
+            "name": "Norra Wexley",
+            "subtitle": "Gold Nine",
+            "limited": 1,
+            "cost": 39,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Missile"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dextiree-battleofyavin": {
+            "name": "Dex Tiree",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 38,
+            "slots": [],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "dorsalturret",
+                "advprotontorpedoes",
+                "r4astromech"
+            ]
+        },
+        "dextiree-battleofyavin-lsl": {
+            "name": "Dex Tiree",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 31,
+            "slots": [
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Missile"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dutchvander-battleofyavin": {
+            "name": "“Dutch” Vander",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 61,
+            "slots": [],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "ioncannonturret",
+                "advprotontorpedoes",
+                "targetingastromech-battleofyavin"
+            ]
+        },
+        "dutchvander-battleofyavin-lsl": {
+            "name": "“Dutch” Vander",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Missile"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "holokand-battleofyavin": {
+            "name": "Hol Okand",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 49,
+            "slots": [],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "dorsalturret",
+                "advprotontorpedoes",
+                "preciseastromech-battleofyavin"
+            ]
+        },
+        "holokand-battleofyavin-lsl": {
+            "name": "Hol Okand",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 34,
+            "slots": [
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Missile"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "popskrail-battleofyavin": {
+            "name": "“Pops” Krail",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 45,
+            "slots": [],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "ioncannonturret",
+                "advprotontorpedoes",
+                "r4astromech"
+            ]
+        },
+        "popskrail-battleofyavin-lsl": {
+            "name": "“Pops” Krail",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 35,
+            "slots": [
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Missile"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "popskrail": {
+            "name": "“Pops” Krail",
+            "subtitle": "Gold Five",
+            "limited": 1,
+            "cost": 36,
+            "slots": [
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Missile"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dutchvander-swz106": {
+            "name": "“Dutch” Vander",
+            "subtitle": "Gold Leader",
+            "limited": 1,
+            "cost": 4,
+            "slots": [],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "ioncannonturret",
+                "protonbombs"
+            ]
+        },
+        "hortonsalm-swz106": {
+            "name": "Horton Salm",
+            "subtitle": "Gray Leader",
+            "limited": 1,
+            "cost": 4,
+            "slots": [],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "ioncannonturret",
+                "proximitymines"
+            ]
+        }
+    },
+    "BTL-S8 K-wing": {
+        "esegetuketu": {
+            "name": "Esege Tuketu",
+            "subtitle": "Selfless Hero",
+            "limited": 1,
+            "cost": 42,
+            "slots": [
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Crew",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "mirandadoni": {
+            "name": "Miranda Doni",
+            "subtitle": "Heavy Hitter",
+            "limited": 1,
+            "cost": 40,
+            "slots": [
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Crew",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "wardensquadronpilot": {
+            "name": "Warden Squadron Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 38,
+            "slots": [
+                "Torpedo",
+                "Missile",
+                "Missile",
+                "Crew",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "CR90 Corellian Corvette": {
+        "alderaanianguard": {
+            "name": "Alderaanian Guard",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 128,
+            "slots": [
+                "Command",
+                "Hardpoint",
+                "Hardpoint",
+                "Crew",
+                "Crew",
+                "Gunner",
+                "Team",
+                "Team",
+                "Cargo",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "Yes"
+        }
+    },
+    "E-wing": {
+        "corranhorn": {
+            "name": "Corran Horn",
+            "subtitle": "Tenacious Investigator",
+            "limited": 1,
+            "cost": 59,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Tech",
+                "Torpedo",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "gavindarklighter": {
+            "name": "Gavin Darklighter",
+            "subtitle": "Bold Wingman",
+            "limited": 1,
+            "cost": 55,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Tech",
+                "Torpedo",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "knavesquadronescort": {
+            "name": "Knave Squadron Escort",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 48,
+            "slots": [
+                "Sensor",
+                "Tech",
+                "Torpedo",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "roguesquadronescort": {
+            "name": "Rogue Squadron Escort",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 51,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Tech",
+                "Torpedo",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Fang Fighter": {
+        "fennrau-fangfighter": {
+            "name": "Fenn Rau",
+            "subtitle": "Mandalorian Protector",
+            "limited": 1,
+            "cost": 55,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Modification"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "bodicavenj": {
+            "name": "Bodica Venj",
+            "subtitle": "Wrathful Warrior",
+            "limited": 1,
+            "cost": 56,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Modification"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dirkullodin": {
+            "name": "Dirk Ullodin",
+            "subtitle": "Aspiring Commando",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Torpedo",
+                "Modification"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "clanwrenvolunteer": {
+            "name": "Clan Wren Volunteer",
+            "subtitle": "Unlikely Ally",
+            "limited": 2,
+            "cost": 44,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Modification"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Gauntlet Fighter": {
+        "chopper-gauntletfighter": {
+            "name": "“Chopper”",
+            "subtitle": "Spectre-3",
+            "limited": 1,
+            "cost": 53,
+            "slots": [
+                "Crew",
+                "Gunner",
+                "Device",
+                "Modification",
+                "Configuration",
+                "Title"
+            ],
+            "keywords": [
+                "Droid",
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ezrabridger-gauntletfighter": {
+            "name": "Ezra Bridger",
+            "subtitle": "Spectre-6",
+            "limited": 1,
+            "cost": 65,
+            "slots": [
+                "Force Power",
+                "Crew",
+                "Gunner",
+                "Device",
+                "Modification",
+                "Configuration",
+                "Title"
+            ],
+            "keywords": [
+                "Light Side",
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "mandalorianresistancepilot": {
+            "name": "Mandalorian Resistance Pilot",
+            "subtitle": "Clan Loyalist",
+            "limited": 0,
+            "cost": 54,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Gunner",
+                "Device",
+                "Modification",
+                "Configuration",
+                "Title"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "GR-75 Medium Transport": {
+        "echobaseevacuees": {
+            "name": "Echo Base Evacuees",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 62,
+            "slots": [
+                "Command",
+                "Hardpoint",
+                "Turret",
+                "Crew",
+                "Crew",
+                "Team",
+                "Cargo",
+                "Cargo",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "Yes"
+        }
+    },
+    "HWK-290 Light Freighter": {
+        "janors": {
+            "name": "Jan Ors",
+            "subtitle": "Espionage Expert",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Device",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "kylekatarn": {
+            "name": "Kyle Katarn",
+            "subtitle": "Relentless Operative",
+            "limited": 1,
+            "cost": 32,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Device",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "rebelscout": {
+            "name": "Rebel Scout",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 26,
+            "slots": [
+                "Crew",
+                "Device",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "roarkgarnet": {
+            "name": "Roark Garnet",
+            "subtitle": "Good-Hearted Smuggler",
+            "limited": 1,
+            "cost": 37,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Device",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Modified YT-1300 Light Freighter": {
+        "chewbacca": {
+            "name": "Chewbacca",
+            "subtitle": "The Mighty",
+            "limited": 1,
+            "cost": 68,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "YT-1300",
+                "Wookiee"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "hansolo-modifiedyt1300lightfreighter": {
+            "name": "Han Solo",
+            "subtitle": "Scoundrel for Hire",
+            "limited": 1,
+            "cost": 81,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "landocalrissian-modifiedyt1300lightfreighter": {
+            "name": "Lando Calrissian",
+            "subtitle": "General of the Alliance",
+            "limited": 1,
+            "cost": 79,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "outerrimsmuggler": {
+            "name": "Outer Rim Smuggler",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 67,
+            "slots": [
+                "Missile",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "leiaorgana": {
+            "name": "Leia Organa",
+            "subtitle": "There Is Another",
+            "limited": 1,
+            "cost": 74,
+            "slots": [
+                "Force Power",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "YT-1300",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "hansolo-battleofyavin": {
+            "name": "Han Solo",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 105,
+            "slots": [],
+            "keywords": [
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "chewbacca-battleofyavin",
+                "riggedcargochute",
+                "millenniumfalcon",
+                "l337sprogramming-battleofyavin"
+            ]
+        },
+        "hansolo-battleofyavin-lsl": {
+            "name": "Han Solo",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 84,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "landocalrissian-battleoverendor": {
+            "name": "Lando Calrissian",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 101,
+            "slots": [],
+            "keywords": [
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "aceinthehole-battleoverendor",
+                "itsatrap-battleoverendor",
+                "niennunb",
+                "airencracken-battleoverendor",
+                "millenniumfalcon-battleoverendor"
+            ]
+        },
+        "landocalrissian-battleoverendor-lsl": {
+            "name": "Lando Calrissian",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 75,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "RZ-1 A-wing": {
+        "arvelcrynyd": {
+            "name": "Arvel Crynyd",
+            "subtitle": "Green Leader",
+            "limited": 1,
+            "cost": 32,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "greensquadronpilot": {
+            "name": "Green Squadron Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "jakefarrell": {
+            "name": "Jake Farrell",
+            "subtitle": "Sage Instructor",
+            "limited": 1,
+            "cost": 36,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "phoenixsquadronpilot": {
+            "name": "Phoenix Squadron Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 28,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "wedgeantilles-rz1awing": {
+            "name": "Wedge Antilles",
+            "subtitle": "Promising Pilot",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sabinewren-rz1awing": {
+            "name": "Sabine Wren",
+            "subtitle": "Daughter of Mandalore",
+            "limited": 1,
+            "cost": 35,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "A-wing",
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "herasyndulla-rz1awing": {
+            "name": "Hera Syndulla",
+            "subtitle": "Phoenix Leader",
+            "limited": 1,
+            "cost": 48,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "A-wing",
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ahsokatano-rz1awing": {
+            "name": "Ahsoka Tano",
+            "subtitle": "Fulcrum",
+            "limited": 1,
+            "cost": 50,
+            "slots": [
+                "Force Power",
+                "Force Power",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "A-wing",
+                "Light Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sharabey-rz1awing": {
+            "name": "Shara Bey",
+            "subtitle": "Green Four",
+            "limited": 1,
+            "cost": 32,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "derekklivian": {
+            "name": "Derek Klivian",
+            "subtitle": "Hobbie",
+            "limited": 1,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "keovenzee": {
+            "name": "Keo Venzee",
+            "subtitle": "Auspicious Ace",
+            "limited": 1,
+            "cost": 35,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "tychocelchu": {
+            "name": "Tycho Celchu",
+            "subtitle": "Son of Alderaan",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Configuration"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "arvelcrynyd-swz106": {
+            "name": "Arvel Crynyd",
+            "subtitle": "Green Leader",
+            "limited": 1,
+            "cost": 37,
+            "slots": [],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "predator",
+                "afterburners"
+            ]
+        },
+        "jakefarrell-swz106": {
+            "name": "Jake Farrell",
+            "subtitle": "Sage Instructor",
+            "limited": 1,
+            "cost": 43,
+            "slots": [],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "elusive",
+                "outmaneuver",
+                "ionmissiles"
+            ]
+        },
+        "sharabey-swz106": {
+            "name": "Shara Bey",
+            "subtitle": "Green Four",
+            "limited": 1,
+            "cost": 36,
+            "slots": [],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "hopeful",
+                "concussionmissiles"
+            ]
+        },
+        "arvelcrynyd-battleoverendor": {
+            "name": "Arvel Crynyd",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 51,
+            "slots": [],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "heroicsacrifice-battleoverendor",
+                "itsatrap-battleoverendor",
+                "protonrockets"
+            ]
+        },
+        "arvelcrynyd-battleoverendor-lsl": {
+            "name": "Arvel Crynyd",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "tychocelchu-battleoverendor": {
+            "name": "Tycho Celchu",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 57,
+            "slots": [],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "itsatrap-battleoverendor",
+                "juke",
+                "protonrockets",
+                "chaffparticles-battleoverendor"
+            ]
+        },
+        "tychocelchu-battleoverendor-lsl": {
+            "name": "Tycho Celchu",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "gemmersojan-battleoverendor": {
+            "name": "Gemmer Sojan",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 46,
+            "slots": [],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "itsatrap-battleoverendor",
+                "precisiontunedcannons-battleoverendor",
+                "chaffparticles-battleoverendor",
+                "targetassistalgorithm-battleoverendor"
+            ]
+        },
+        "gemmersojan-battleoverendor-lsl": {
+            "name": "Gemmer Sojan",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 33,
+            "slots": [
+                "Talent",
+                "Missile"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Sheathipede-class Shuttle": {
+        "zeborrelios-sheathipedeclassshuttle": {
+            "name": "“Zeb” Orrelios",
+            "subtitle": "Spectre-4",
+            "limited": 1,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ap5": {
+            "name": "AP-5",
+            "subtitle": "Escaped Analyst Droid",
+            "limited": 1,
+            "cost": 31,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Droid",
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ezrabridger-sheathipedeclassshuttle": {
+            "name": "Ezra Bridger",
+            "subtitle": "Spectre-6",
+            "limited": 1,
+            "cost": 37,
+            "slots": [
+                "Force Power",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Light Side",
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "fennrau-sheathipedeclassshuttle": {
+            "name": "Fenn Rau",
+            "subtitle": "Reluctant Rebel",
+            "limited": 1,
+            "cost": 45,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Astromech",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Mandalorian",
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "T-65 X-wing": {
+        "biggsdarklighter": {
+            "name": "Biggs Darklighter",
+            "subtitle": "Red Three",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Torpedo",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "bluesquadronescort": {
+            "name": "Blue Squadron Escort",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 38,
+            "slots": [
+                "Torpedo",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "cavernangelszealot": {
+            "name": "Cavern Angels Zealot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 38,
+            "slots": [
+                "Torpedo",
+                "Astromech",
+                "Illicit",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Partisan",
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "edriotwotubes": {
+            "name": "Edrio Two Tubes",
+            "subtitle": "Cavern Angels Veteran",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Torpedo",
+                "Astromech",
+                "Illicit",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Partisan",
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "garvendreis-t65xwing": {
+            "name": "Garven Dreis",
+            "subtitle": "Red Leader",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "jekporkins": {
+            "name": "Jek Porkins",
+            "subtitle": "Red Six",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "kullbeesperado": {
+            "name": "Kullbee Sperado",
+            "subtitle": "Enigmatic Gunslinger",
+            "limited": 1,
+            "cost": 42,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Astromech",
+                "Illicit",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Partisan",
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "leevantenza": {
+            "name": "Leevan Tenza",
+            "subtitle": "Rebel Alliance Defector",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Astromech",
+                "Illicit",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Partisan",
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lukeskywalker": {
+            "name": "Luke Skywalker",
+            "subtitle": "Red Five",
+            "limited": 1,
+            "cost": 59,
+            "slots": [
+                "Force Power",
+                "Torpedo",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Light Side",
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "redsquadronveteran": {
+            "name": "Red Squadron Veteran",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 40,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "thanekyrell": {
+            "name": "Thane Kyrell",
+            "subtitle": "Corona Four",
+            "limited": 1,
+            "cost": 48,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "wedgeantilles": {
+            "name": "Wedge Antilles",
+            "subtitle": "Red Two",
+            "limited": 1,
+            "cost": 57,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "biggsdarklighter-battleofyavin": {
+            "name": "Biggs Darklighter",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 56,
+            "slots": [],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "attackspeed-battleofyavin",
+                "selfless",
+                "protontorpedoes",
+                "r2f2-battleofyavin"
+            ]
+        },
+        "biggsdarklighter-battleofyavin-lsl": {
+            "name": "Biggs Darklighter",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Torpedo",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "garvendreis-battleofyavin": {
+            "name": "Garven Dreis",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 53,
+            "slots": [],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "advprotontorpedoes",
+                "r5k6-battleofyavin"
+            ]
+        },
+        "garvendreis-battleofyavin-lsl": {
+            "name": "Garven Dreis",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 47,
+            "slots": [
+                "Torpedo",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "jekporkins-battleofyavin": {
+            "name": "Jek Porkins",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 54,
+            "slots": [],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "advprotontorpedoes",
+                "r5d8-battleofyavin",
+                "unstablesublightengines-battleofyavin"
+            ]
+        },
+        "jekporkins-battleofyavin-lsl": {
+            "name": "Jek Porkins",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 42,
+            "slots": [
+                "Torpedo",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lukeskywalker-battleofyavin": {
+            "name": "Luke Skywalker",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 79,
+            "slots": [],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "attackspeed-battleofyavin",
+                "instinctiveaim",
+                "protontorpedoes",
+                "r2d2-battleofyavin"
+            ]
+        },
+        "lukeskywalker-battleofyavin-lsl": {
+            "name": "Luke Skywalker",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 60,
+            "slots": [
+                "Force Power",
+                "Torpedo",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "wedgeantilles-battleofyavin": {
+            "name": "Wedge Antilles",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 65,
+            "slots": [],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "attackspeed-battleofyavin",
+                "marksmanship",
+                "protontorpedoes",
+                "r2a3-battleofyavin"
+            ]
+        },
+        "wedgeantilles-battleofyavin-lsl": {
+            "name": "Wedge Antilles",
+            "subtitle": "Battle of Yavin",
+            "limited": 1,
+            "cost": 49,
+            "slots": [
+                "Torpedo",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "corranhorn-t65xwing": {
+            "name": "Corran Horn",
+            "subtitle": "Rogue Nine",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "wesjanson": {
+            "name": "Wes Janson",
+            "subtitle": "Wisecracking Wingman",
+            "limited": 1,
+            "cost": 50,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lukeskywalker-swz106": {
+            "name": "Luke Skywalker",
+            "subtitle": "Red Five",
+            "limited": 1,
+            "cost": 75,
+            "slots": [],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "instinctiveaim",
+                "protontorpedoes",
+                "r2d2"
+            ]
+        },
+        "jekporkins-swz106": {
+            "name": "Jek Porkins",
+            "subtitle": "Red Six",
+            "limited": 1,
+            "cost": 54,
+            "slots": [],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "predator",
+                "protontorpedoes",
+                "r5d8-battleofyavin"
+            ]
+        },
+        "wedgeantilles-battleoverendor": {
+            "name": "Wedge Antilles",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 70,
+            "slots": [],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "itsatrap-battleoverendor",
+                "predator",
+                "advprotontorpedoes",
+                "r2a3-battleoverendor"
+            ]
+        },
+        "wedgeantilles-battleoverendor-lsl": {
+            "name": "Wedge Antilles",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 55,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Astromech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "yendor-battleoverendor": {
+            "name": "Yendor",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 61,
+            "slots": [],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "itsatrap-battleoverendor",
+                "plasmatorpedoes",
+                "stabilizingastromech-battleoverendor"
+            ]
+        },
+        "yendor-battleoverendor-lsl": {
+            "name": "Yendor",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 50,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "kendyidele-battleoverendor": {
+            "name": "Kendy Idele",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 57,
+            "slots": [],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "itsatrap-battleoverendor",
+                "ionmissiles",
+                "modifiedr4punit-battleoverendor",
+                "chaffparticles-battleoverendor"
+            ]
+        },
+        "kendyidele-battleoverendor-lsl": {
+            "name": "Kendy Idele",
+            "subtitle": "Battle Over Endor",
+            "limited": 1,
+            "cost": 48,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "antocmerrick-wat1": {
+            "name": "Antoc Merrick",
+            "subtitle": "Blue Leader",
+            "limited": 1,
+            "cost": 45,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Astromech",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "TIE/ln Fighter": {
+        "zeborrelios-tielnfighter": {
+            "name": "“Zeb” Orrelios",
+            "subtitle": "Spectre-4",
+            "limited": 1,
+            "cost": 21,
+            "slots": [
+                "Modification"
+            ],
+            "keywords": [
+                "TIE",
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "captainrex": {
+            "name": "Captain Rex",
+            "subtitle": "Clone Wars Veteran",
+            "limited": 1,
+            "cost": 25,
+            "slots": [
+                "Modification"
+            ],
+            "keywords": [
+                "Clone",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ezrabridger-tielnfighter": {
+            "name": "Ezra Bridger",
+            "subtitle": "Spectre-6",
+            "limited": 1,
+            "cost": 25,
+            "slots": [
+                "Force Power",
+                "Modification"
+            ],
+            "keywords": [
+                "Light Side",
+                "Spectre",
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sabinewren-tielnfighter": {
+            "name": "Sabine Wren",
+            "subtitle": "Spectre-5",
+            "limited": 1,
+            "cost": 25,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "Mandalorian",
+                "TIE",
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "UT-60D U-wing": {
+        "benthictwotubes": {
+            "name": "Benthic Two Tubes",
+            "subtitle": "Cavern Angels Marksman",
+            "limited": 1,
+            "cost": 45,
+            "slots": [
+                "Sensor",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Partisan"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "bluesquadronscout": {
+            "name": "Blue Squadron Scout",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 43,
+            "slots": [
+                "Sensor",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "bodhirook": {
+            "name": "Bodhi Rook",
+            "subtitle": "Imperial Defector",
+            "limited": 1,
+            "cost": 48,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "cassianandor": {
+            "name": "Cassian Andor",
+            "subtitle": "Raised by the Rebellion",
+            "limited": 1,
+            "cost": 49,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "hefftobber": {
+            "name": "Heff Tobber",
+            "subtitle": "Blue Eight",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "magvayarro": {
+            "name": "Magva Yarro",
+            "subtitle": "Cavern Angels Spotter",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Partisan"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "partisanrenegade": {
+            "name": "Partisan Renegade",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 43,
+            "slots": [
+                "Sensor",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Partisan"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sawgerrera": {
+            "name": "Saw Gerrera",
+            "subtitle": "Obsessive Outlaw",
+            "limited": 1,
+            "cost": 50,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Partisan"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "k2so": {
+            "name": "K-2SO",
+            "subtitle": "Cassian Said I Had To",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "VCX-100 Light Freighter": {
+        "chopper": {
+            "name": "“Chopper”",
+            "subtitle": "Spectre-3",
+            "limited": 1,
+            "cost": 66,
+            "slots": [
+                "Sensor",
+                "Turret",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Droid",
+                "Freighter",
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "herasyndulla-vcx100lightfreighter": {
+            "name": "Hera Syndulla",
+            "subtitle": "Spectre-2",
+            "limited": 1,
+            "cost": 74,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Turret",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "kananjarrus": {
+            "name": "Kanan Jarrus",
+            "subtitle": "Spectre-1",
+            "limited": 1,
+            "cost": 75,
+            "slots": [
+                "Sensor",
+                "Turret",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Title",
+                "Gunner",
+                "Force Power"
+            ],
+            "keywords": [
+                "Freighter",
+                "Jedi",
+                "Light Side",
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lothalrebel": {
+            "name": "Lothal Rebel",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 68,
+            "slots": [
+                "Sensor",
+                "Turret",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "alexsandrkallus": {
+            "name": "Alexsandr Kallus",
+            "subtitle": "Fulcrum",
+            "limited": 1,
+            "cost": 68,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Turret",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Gunner",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Freighter",
+                "Spectre"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "YT-2400 Light Freighter": {
+        "leebo": {
+            "name": "“Leebo”",
+            "subtitle": "Dry-Witted Droid",
+            "limited": 1,
+            "cost": 75,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Droid",
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dashrendar": {
+            "name": "Dash Rendar",
+            "subtitle": "Hotshot Mercenary",
+            "limited": 1,
+            "cost": 83,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "wildspacefringer": {
+            "name": "Wild Space Fringer",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 69,
+            "slots": [
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "YT-2400 Light Freighter (2023)": {
+        "dashrendar-swz103-rebelalliance": {
+            "name": "Dash Rendar",
+            "subtitle": "Freighter for Hire",
+            "limited": 1,
+            "cost": 77,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dashrendar-swz103-lsl-rebelalliance": {
+            "name": "Dash Rendar",
+            "subtitle": "In it for Himself",
+            "limited": 1,
+            "cost": 74,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Droid",
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dashrendar-swz103-sl-rebelalliance": {
+            "name": "Dash Rendar",
+            "subtitle": "In it for Himself",
+            "limited": 1,
+            "cost": 90,
+            "slots": [],
+            "keywords": [
+                "Droid",
+                "Freighter"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "mercenary-swz103",
+                "seekermissiles-swz103",
+                "leebo-swz103",
+                "outrider"
+            ]
+        },
+        "leebo-swz103-rebelalliance": {
+            "name": "“Leebo”",
+            "subtitle": "Wisdom of Ages",
+            "limited": 1,
+            "cost": 71,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Droid",
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "leebo-swz103-lsl-rebelalliance": {
+            "name": "“Leebo”",
+            "subtitle": "He Thinks He's Funny",
+            "limited": 1,
+            "cost": 69,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Missile",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Droid",
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "leebo-swz103-sl-rebelalliance": {
+            "name": "“Leebo”",
+            "subtitle": "He Thinks He's Funny",
+            "limited": 1,
+            "cost": 83,
+            "slots": [],
+            "keywords": [
+                "Droid",
+                "Freighter"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "efficientprocessing-swz103",
+                "seekermissiles-swz103",
+                "outrider"
+            ]
+        }
+    },
+    "Z-95-AF4 Headhunter": {
+        "airencracken": {
+            "name": "Airen Cracken",
+            "subtitle": "Intelligence Chief",
+            "limited": 1,
+            "cost": 35,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "banditsquadronpilot": {
+            "name": "Bandit Squadron Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 22,
+            "slots": [
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lieutenantblount": {
+            "name": "Lieutenant Blount",
+            "subtitle": "Team Player",
+            "limited": 1,
+            "cost": 28,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "talasquadronpilot": {
+            "name": "Tala Squadron Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 23,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    }
+}

--- a/X2PO/dec2025/resistance.json
+++ b/X2PO/dec2025/resistance.json
@@ -1,0 +1,1403 @@
+{
+    "GR-75 Medium Transport": {
+        "newrepublicvolunteers": {
+            "name": "New Republic Volunteers",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 62,
+            "slots": [
+                "Command",
+                "Hardpoint",
+                "Turret",
+                "Crew",
+                "Crew",
+                "Team",
+                "Cargo",
+                "Cargo"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "Yes"
+        }
+    },
+    "MG-100 StarFortress": {
+        "cobaltsquadronbomber": {
+            "name": "Cobalt Squadron Bomber",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 49,
+            "slots": [
+                "Sensor",
+                "Crew",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner",
+                "Gunner",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "cat": {
+            "name": "Cat",
+            "subtitle": "Cobalt Wasp",
+            "limited": 1,
+            "cost": 50,
+            "slots": [
+                "Sensor",
+                "Crew",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner",
+                "Gunner",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "vennie": {
+            "name": "Vennie",
+            "subtitle": "Crimson Cutter",
+            "limited": 1,
+            "cost": 51,
+            "slots": [
+                "Sensor",
+                "Crew",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner",
+                "Gunner",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "benteene": {
+            "name": "Ben Teene",
+            "subtitle": "Crimson Bolide",
+            "limited": 1,
+            "cost": 51,
+            "slots": [
+                "Sensor",
+                "Crew",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner",
+                "Gunner",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "edonkappehl": {
+            "name": "Edon Kappehl",
+            "subtitle": "Crimson Hailstorm",
+            "limited": 1,
+            "cost": 52,
+            "slots": [
+                "Sensor",
+                "Crew",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner",
+                "Gunner",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "finchdallow": {
+            "name": "Finch Dallow",
+            "subtitle": "Cobalt Hammer",
+            "limited": 1,
+            "cost": 52,
+            "slots": [
+                "Sensor",
+                "Crew",
+                "Device",
+                "Device",
+                "Modification",
+                "Gunner",
+                "Gunner",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "paigetico": {
+            "name": "Paige Tico",
+            "subtitle": "Hero",
+            "limited": 1,
+            "cost": 53,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Tech",
+                "Crew",
+                "Gunner",
+                "Gunner",
+                "Device",
+                "Device",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Scavenged YT-1300": {
+        "resistancesympathizer": {
+            "name": "Resistance Sympathizer",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 55,
+            "slots": [
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "chewbacca-scavengedyt1300": {
+            "name": "Chewbacca",
+            "subtitle": "Loyal Companion",
+            "limited": 1,
+            "cost": 59,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "hansolo-scavengedyt1300": {
+            "name": "Han Solo",
+            "subtitle": "Jaded Smuggler",
+            "limited": 1,
+            "cost": 60,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "rey": {
+            "name": "Rey",
+            "subtitle": "Resourceful Scavenger",
+            "limited": 1,
+            "cost": 71,
+            "slots": [
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title",
+                "Gunner",
+                "Force Power"
+            ],
+            "keywords": [
+                "Freighter",
+                "Light Side",
+                "YT-1300"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "poedameron-scavengedyt1300": {
+            "name": "Poe Dameron",
+            "subtitle": "A Difficult Man",
+            "limited": 1,
+            "cost": 67,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "landocalrissian-scavengedyt1300": {
+            "name": "Lando Calrissian",
+            "subtitle": "Old General",
+            "limited": 1,
+            "cost": 71,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "RZ-2 A-wing": {
+        "lulolampar": {
+            "name": "L’ulo L’ampar",
+            "subtitle": "Luminous Mentor",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Tech"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "tallissanlintra": {
+            "name": "Tallissan Lintra",
+            "subtitle": "Deadly Approach",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Tech"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "zaribangel": {
+            "name": "Zari Bangel",
+            "subtitle": "Aerial Exhibitionist",
+            "limited": 1,
+            "cost": 34,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Tech"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "greersonnel": {
+            "name": "Greer Sonnel",
+            "subtitle": "Kothan Si",
+            "limited": 1,
+            "cost": 36,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Tech"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "greensquadronexpert": {
+            "name": "Green Squadron Expert",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 33,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Tech"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "bluesquadronrecruit": {
+            "name": "Blue Squadron Recruit",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 32,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Tech"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "zizitlo": {
+            "name": "Zizi Tlo",
+            "subtitle": "Committed to the Cause",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Tech",
+                "Missile"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ronithblario": {
+            "name": "Ronith Blario",
+            "subtitle": "Reckless Rookie",
+            "limited": 1,
+            "cost": 33,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Missile"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "merlcobben": {
+            "name": "Merl Cobben",
+            "subtitle": "Distracting Daredevil",
+            "limited": 1,
+            "cost": 34,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Tech"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "suralindajavos": {
+            "name": "Suralinda Javos",
+            "subtitle": "Inquisitive Journalist",
+            "limited": 1,
+            "cost": 34,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Tech"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "wrobietyce": {
+            "name": "Wrobie Tyce",
+            "subtitle": "Dynamic Aerialist",
+            "limited": 1,
+            "cost": 35,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Tech"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "seftinvanik": {
+            "name": "Seftin Vanik",
+            "subtitle": "Skillful Wingmate",
+            "limited": 1,
+            "cost": 37,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Missile",
+                "Tech"
+            ],
+            "keywords": [
+                "A-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "T-70 X-wing": {
+        "poedameron": {
+            "name": "Poe Dameron",
+            "subtitle": "Trigger-Happy Flyboy",
+            "limited": 1,
+            "cost": 64,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "poedameron-swz68": {
+            "name": "Poe Dameron",
+            "subtitle": "Resistance Commander",
+            "limited": 1,
+            "cost": 57,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "bluesquadronrookie": {
+            "name": "Blue Squadron Rookie",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 42,
+            "slots": [
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "redsquadronexpert": {
+            "name": "Red Squadron Expert",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 44,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "blacksquadronace-t70xwing": {
+            "name": "Black Squadron Ace",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "elloasty": {
+            "name": "Ello Asty",
+            "subtitle": "Born to Ill",
+            "limited": 1,
+            "cost": 53,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "jophseastriker": {
+            "name": "Joph Seastriker",
+            "subtitle": "Reckless Bodyguard",
+            "limited": 1,
+            "cost": 45,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "karekun": {
+            "name": "Kare Kun",
+            "subtitle": "Woman of Action",
+            "limited": 1,
+            "cost": 47,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lieutenantbastian": {
+            "name": "Lieutenant Bastian",
+            "subtitle": "Optimistic Analyst",
+            "limited": 1,
+            "cost": 48,
+            "slots": [
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "niennunb": {
+            "name": "Nien Nunb",
+            "subtitle": "Sarcastic Survivor",
+            "limited": 1,
+            "cost": 56,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "jaycristubbs": {
+            "name": "Jaycris Tubbs",
+            "subtitle": "Loving Father",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "jessikapava": {
+            "name": "Jessika Pava",
+            "subtitle": "The Great Destroyer",
+            "limited": 1,
+            "cost": 51,
+            "slots": [
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "temminwexley": {
+            "name": "Temmin Wexley",
+            "subtitle": "Snap",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "temminwexley-swz68": {
+            "name": "Temmin Wexley",
+            "subtitle": "Black Two",
+            "limited": 1,
+            "cost": 53,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "caithrenalli": {
+            "name": "C’ai Threnalli",
+            "subtitle": "Tenacious Survivor",
+            "limited": 1,
+            "cost": 47,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "nimichireen": {
+            "name": "Nimi Chireen",
+            "subtitle": "Hopeful Hero",
+            "limited": 1,
+            "cost": 48,
+            "slots": [
+                "Tech",
+                "Astromech",
+                "Modification",
+                "Configuration",
+                "Title"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "venisadoza": {
+            "name": "Venisa Doza",
+            "subtitle": "Jade Leader",
+            "limited": 1,
+            "cost": 48,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "zayversio": {
+            "name": "Zay Versio",
+            "subtitle": "Her Father's Daughter",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Astromech",
+                "Modification",
+                "Title",
+                "Configuration",
+                "Tech"
+            ],
+            "keywords": [
+                "X-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Resistance Transport": {
+        "covanell": {
+            "name": "Cova Nell",
+            "subtitle": "Evacuation Escort",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "pammichnerrogoode": {
+            "name": "Pammich Nerro Goode",
+            "subtitle": "D’Qar Dispatcher",
+            "limited": 1,
+            "cost": 31,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "nodinchavdri": {
+            "name": "Nodin Chavdri",
+            "subtitle": "Insubordinate Insurgent",
+            "limited": 1,
+            "cost": 33,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "logisticsdivisionpilot": {
+            "name": "Logistics Division Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 30,
+            "slots": [
+                "Tech",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "takajamoreesa": {
+            "name": "Taka Jamoreesa",
+            "subtitle": "Snograth Enthusiast",
+            "limited": 1,
+            "cost": 31,
+            "slots": [
+                "Tech",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "jannah-wat1": {
+            "name": "Jannah",
+            "subtitle": "Orbak Rider",
+            "limited": 1,
+            "cost": 42,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Cannon",
+                "Cannon",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Astromech",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Resistance Transport Pod": {
+        "bb8": {
+            "name": "BB-8",
+            "subtitle": "Full of Surprises",
+            "limited": 1,
+            "cost": 23,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Crew",
+                "Modification"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "rosetico": {
+            "name": "Rose Tico",
+            "subtitle": "Earnest Engineer",
+            "limited": 1,
+            "cost": 26,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Crew",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "vimoradi": {
+            "name": "Vi Moradi",
+            "subtitle": "Starling",
+            "limited": 1,
+            "cost": 24,
+            "slots": [
+                "Tech",
+                "Crew",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "finn": {
+            "name": "Finn",
+            "subtitle": "Big Deal",
+            "limited": 1,
+            "cost": 31,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Crew",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dj-wat1": {
+            "name": "DJ",
+            "subtitle": "Don't Join",
+            "limited": 1,
+            "cost": 25,
+            "slots": [
+                "Illicit",
+                "Tech",
+                "Crew",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Fireball": {
+        "colossusstationmechanic": {
+            "name": "Colossus Station Mechanic",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 26,
+            "slots": [
+                "Missile",
+                "Astromech",
+                "Illicit",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "jarekyeager": {
+            "name": "Jarek Yeager",
+            "subtitle": "Too Old for This",
+            "limited": 1,
+            "cost": 28,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Astromech",
+                "Illicit",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "kazudaxiono": {
+            "name": "Kazuda Xiono",
+            "subtitle": "Best Pilot in the Galaxy",
+            "limited": 1,
+            "cost": 37,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Astromech",
+                "Illicit",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "r1j5": {
+            "name": "R1-J5",
+            "subtitle": "Bucket",
+            "limited": 1,
+            "cost": 24,
+            "slots": [
+                "Missile",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "torradoza-wat1": {
+            "name": "Torra Doza",
+            "subtitle": "Daughter of the Resistance",
+            "limited": 1,
+            "cost": 27,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Astromech",
+                "Illicit",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "BTA-NR2 Y-Wing": {
+        "zoriibliss": {
+            "name": "Zorii Bliss",
+            "subtitle": "Corsair of Kijimi",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Turret",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Illicit",
+                "Configuration"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "tezanasz": {
+            "name": "Teza Nasz",
+            "subtitle": "Old Soldier",
+            "limited": 1,
+            "cost": 35,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Turret",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "wilsateshlo": {
+            "name": "Wilsa Teshlo",
+            "subtitle": "Veiled Sorority Privateer",
+            "limited": 1,
+            "cost": 31,
+            "slots": [
+                "Tech",
+                "Turret",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "shasazaro": {
+            "name": "Shasa Zaro",
+            "subtitle": "Artistic Ace",
+            "limited": 1,
+            "cost": 31,
+            "slots": [
+                "Tech",
+                "Turret",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "legafossang": {
+            "name": "Lega Fossang",
+            "subtitle": "Hero of Humbarine",
+            "limited": 1,
+            "cost": 31,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Turret",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "aftabackbar": {
+            "name": "Aftab Ackbar",
+            "subtitle": "“Junior”",
+            "limited": 1,
+            "cost": 32,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Turret",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "coruskapellim": {
+            "name": "Corus Kapellim",
+            "subtitle": "“Gentleman Flyer”",
+            "limited": 1,
+            "cost": 30,
+            "slots": [
+                "Tech",
+                "Turret",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Illicit",
+                "Configuration"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "caithrenalli-btanr2ywing": {
+            "name": "C’ai Threnalli",
+            "subtitle": "Tenacious Survivor",
+            "limited": 1,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Turret",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "newrepublicpatrol": {
+            "name": "New Republic Patrol",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Turret",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "kijimispicerunner": {
+            "name": "Kijimi Spice Runner",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 29,
+            "slots": [
+                "Tech",
+                "Turret",
+                "Astromech",
+                "Device",
+                "Modification",
+                "Illicit",
+                "Configuration"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    }
+}

--- a/X2PO/dec2025/revision.json
+++ b/X2PO/dec2025/revision.json
@@ -1,0 +1,16 @@
+{
+    "effective_date": "2025-12-10",
+    "format": "December 2025 update",
+    "author": "X2PO",
+    "subject": "The X-Wing 2.0 Legacy regular points update with Warrior and Turncoats release",
+    "files": {
+        "rebelalliance": "X2PO/dec2025/rebelalliance.json",
+        "galacticempire": "X2PO/dec2025/galacticempire.json",
+        "scumandvillainy": "X2PO/dec2025/scumandvillainy.json",
+        "resistance": "X2PO/dec2025/resistance.json",
+        "firstorder": "X2PO/dec2025/firstorder.json",
+        "galacticrepublic": "X2PO/dec2025/galacticrepublic.json",
+        "separatistalliance": "X2PO/dec2025/separatistalliance.json",
+        "upgrades": "X2PO/dec2025/upgrades.json"
+    }
+}

--- a/X2PO/dec2025/scumandvillainy.json
+++ b/X2PO/dec2025/scumandvillainy.json
@@ -1,0 +1,2436 @@
+{
+    "Aggressor Assault Fighter": {
+        "ig88a": {
+            "name": "IG-88A",
+            "subtitle": "Aggressive Automaton",
+            "limited": 1,
+            "cost": 60,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Cannon",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter",
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ig88b": {
+            "name": "IG-88B",
+            "subtitle": "Brutal Battledroid",
+            "limited": 1,
+            "cost": 60,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Cannon",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter",
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ig88c": {
+            "name": "IG-88C",
+            "subtitle": "Conniving Contraption",
+            "limited": 1,
+            "cost": 60,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Cannon",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter",
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ig88d": {
+            "name": "IG-88D",
+            "subtitle": "Deadly Device",
+            "limited": 1,
+            "cost": 60,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Cannon",
+                "Cannon",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter",
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "BTL-A4 Y-wing": {
+        "crymorahgoon": {
+            "name": "Crymorah Goon",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 29,
+            "slots": [
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Missile"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "drearenthal": {
+            "name": "Drea Renthal",
+            "subtitle": "Pirate Lord",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Missile"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "hiredgun": {
+            "name": "Hired Gun",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Missile"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "kavil": {
+            "name": "Kavil",
+            "subtitle": "Callous Corsair",
+            "limited": 1,
+            "cost": 40,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Torpedo",
+                "Astromech",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Missile"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "leemakai": {
+            "name": "Leema Kai",
+            "subtitle": "Opportunity Knocks",
+            "limited": 1,
+            "cost": 37,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Turret",
+                "Torpedo",
+                "Missile",
+                "Astromech",
+                "Device"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "arlizhadrassian": {
+            "name": "Arliz Hadrassian",
+            "subtitle": "Crimson Blade",
+            "limited": 1,
+            "cost": 35,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Turret",
+                "Torpedo",
+                "Missile",
+                "Astromech",
+                "Device"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "amaxinewarrior": {
+            "name": "Amaxine Warrior",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 31,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Turret",
+                "Torpedo",
+                "Missile",
+                "Astromech",
+                "Device"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "padric": {
+            "name": "Padric",
+            "subtitle": "Napkin Bomber",
+            "limited": 1,
+            "cost": 32,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Turret",
+                "Torpedo",
+                "Missile",
+                "Astromech",
+                "Device"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "jinatasecurityofficer": {
+            "name": "Jinata Security Officer",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 39,
+            "slots": [
+                "Tech",
+                "Turret",
+                "Torpedo",
+                "Missile",
+                "Astromech",
+                "Device"
+            ],
+            "keywords": [
+                "Y-wing"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "C-ROC Cruiser": {
+        "syndicatesmugglers": {
+            "name": "Syndicate Smugglers",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 63,
+            "slots": [
+                "Command",
+                "Hardpoint",
+                "Crew",
+                "Crew",
+                "Team",
+                "Cargo",
+                "Device",
+                "Illicit",
+                "Title",
+                "Configuration"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "Yes"
+        }
+    },
+    "Customized YT-1300 Light Freighter": {
+        "freightercaptain": {
+            "name": "Freighter Captain",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 41,
+            "slots": [
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "hansolo": {
+            "name": "Han Solo",
+            "subtitle": "The Corellian Kid",
+            "limited": 1,
+            "cost": 47,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "l337": {
+            "name": "L3-37",
+            "subtitle": "Droid Revolutionary",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Missile",
+                "Crew",
+                "Crew",
+                "Gunner",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Droid",
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "landocalrissian": {
+            "name": "Lando Calrissian",
+            "subtitle": "Smooth-talking Gambler",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "riodurant-wat1": {
+            "name": "Rio Durant",
+            "subtitle": "Four Armed Bandit",
+            "limited": 1,
+            "cost": 42,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter",
+                "YT-1300"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Escape Craft": {
+        "autopilotdrone": {
+            "name": "Autopilot Drone",
+            "subtitle": "Set to Blow",
+            "limited": 1,
+            "cost": 11,
+            "slots": [],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "l337-escapecraft": {
+            "name": "L3-37",
+            "subtitle": "Droid Revolutionary",
+            "limited": 1,
+            "cost": 25,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Modification"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "landocalrissian-escapecraft": {
+            "name": "Lando Calrissian",
+            "subtitle": "Smooth-talking Gambler",
+            "limited": 1,
+            "cost": 27,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "outerrimpioneer": {
+            "name": "Outer Rim Pioneer",
+            "subtitle": "Skillful Outlaw",
+            "limited": 1,
+            "cost": 26,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Fang Fighter": {
+        "fennrau": {
+            "name": "Fenn Rau",
+            "subtitle": "Skull Leader",
+            "limited": 1,
+            "cost": 69,
+            "slots": [
+                "Talent",
+                "Torpedo"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "joyrekkoff": {
+            "name": "Joy Rekkoff",
+            "subtitle": "Skull Squadron Ace",
+            "limited": 1,
+            "cost": 45,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Modification"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "kadsolus": {
+            "name": "Kad Solus",
+            "subtitle": "Skilled Commando",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Modification"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "oldteroch": {
+            "name": "Old Teroch",
+            "subtitle": "Mandalorian Mentor",
+            "limited": 1,
+            "cost": 57,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Modification"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "skullsquadronpilot": {
+            "name": "Skull Squadron Pilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 44,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Modification"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "zealousrecruit": {
+            "name": "Zealous Recruit",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 41,
+            "slots": [
+                "Torpedo",
+                "Modification"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "mandalorianroyalguard": {
+            "name": "Mandalorian Royal Guard",
+            "subtitle": "Selfless Protector",
+            "limited": 2,
+            "cost": 45,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Modification"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "torphun": {
+            "name": "Tor Phun",
+            "subtitle": "Direct Pressure",
+            "limited": 1,
+            "cost": 47,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Modification"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Firespray-class Patrol Craft": {
+        "bobafett": {
+            "name": "Boba Fett",
+            "subtitle": "Notorious Bounty Hunter",
+            "limited": 1,
+            "cost": 90,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Missile",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "bountyhunter": {
+            "name": "Bounty Hunter",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 62,
+            "slots": [
+                "Cannon",
+                "Missile",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "emonazzameen": {
+            "name": "Emon Azzameen",
+            "subtitle": "Shipping Magnate",
+            "limited": 1,
+            "cost": 69,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Missile",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "kathscarlet": {
+            "name": "Kath Scarlet",
+            "subtitle": "Captain of the Binayre Pirates",
+            "limited": 1,
+            "cost": 67,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Missile",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "koshkafrost": {
+            "name": "Koshka Frost",
+            "subtitle": "Icy Professional",
+            "limited": 1,
+            "cost": 69,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Missile",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "krassistrelix": {
+            "name": "Krassis Trelix",
+            "subtitle": "Imperial Deserter",
+            "limited": 1,
+            "cost": 65,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Missile",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "hondoohnaka": {
+            "name": "Hondo Ohnaka",
+            "subtitle": "I Smell Profit!",
+            "limited": 1,
+            "cost": 63,
+            "slots": [
+                "Cannon",
+                "Missile",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "G-1A Starfighter": {
+        "4lom": {
+            "name": "4-LOM",
+            "subtitle": "Reprogrammed Protocol Droid",
+            "limited": 1,
+            "cost": 45,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter",
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "gandfindsman": {
+            "name": "Gand Findsman",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 39,
+            "slots": [
+                "Sensor",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "zuckuss": {
+            "name": "Zuckuss",
+            "subtitle": "Meditative Gand",
+            "limited": 1,
+            "cost": 42,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Gauntlet Fighter": {
+        "maul": {
+            "name": "Maul",
+            "subtitle": "Lord of the Shadow Collective",
+            "limited": 1,
+            "cost": 73,
+            "slots": [
+                "Force Power",
+                "Crew",
+                "Gunner",
+                "Illicit",
+                "Device",
+                "Modification",
+                "Configuration",
+                "Title"
+            ],
+            "keywords": [
+                "Dark Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "rookkast": {
+            "name": "Rook Kast",
+            "subtitle": "Stoic Super Commando",
+            "limited": 1,
+            "cost": 61,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Gunner",
+                "Illicit",
+                "Device",
+                "Modification",
+                "Configuration",
+                "Title"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "shadowcollectiveoperator": {
+            "name": "Shadow Collective Operator",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 53,
+            "slots": [
+                "Crew",
+                "Gunner",
+                "Illicit",
+                "Device",
+                "Modification",
+                "Configuration",
+                "Title"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "HWK-290 Light Freighter": {
+        "dacebonearm": {
+            "name": "Dace Bonearm",
+            "subtitle": "Outer Rim Mercenary",
+            "limited": 1,
+            "cost": 29,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "palobgodalhi": {
+            "name": "Palob Godalhi",
+            "subtitle": "Tethan Resister",
+            "limited": 1,
+            "cost": 40,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "spicerunner": {
+            "name": "Spice Runner",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 26,
+            "slots": [
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "torkilmux": {
+            "name": "Torkil Mux",
+            "subtitle": "Mercenary Miner",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "gamutkey": {
+            "name": "Gamut Key",
+            "subtitle": "Collaborationist Governor",
+            "limited": 1,
+            "cost": 31,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "kananjarrus-hwk290lightfreighter": {
+            "name": "Kanan Jarrus",
+            "subtitle": "Lost Padawan",
+            "limited": 1,
+            "cost": 40,
+            "slots": [
+                "Force Power",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Jedi",
+                "Light Side",
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "tapusk": {
+            "name": "Tápusk",
+            "subtitle": "Order 66 Informant",
+            "limited": 1,
+            "cost": 33,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "januskasmir-wat1": {
+            "name": "Janus Kasmir",
+            "subtitle": "Kalleran Scoundrel",
+            "limited": 1,
+            "cost": 34,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "JumpMaster 5000": {
+        "contractedscout": {
+            "name": "Contracted Scout",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 41,
+            "slots": [
+                "Cannon",
+                "Torpedo",
+                "Crew",
+                "Gunner",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dengar": {
+            "name": "Dengar",
+            "subtitle": "Vengeful Corellian",
+            "limited": 1,
+            "cost": 53,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Torpedo",
+                "Crew",
+                "Gunner",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "manaroo": {
+            "name": "Manaroo",
+            "subtitle": "Graceful Aruzan",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Torpedo",
+                "Crew",
+                "Gunner",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "teltrevura": {
+            "name": "Tel Trevura",
+            "subtitle": "Escape Artist",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Torpedo",
+                "Crew",
+                "Gunner",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "nomlumb": {
+            "name": "Nom Lumb",
+            "subtitle": "On the Run",
+            "limited": 1,
+            "cost": 37,
+            "slots": [
+                "Cannon",
+                "Torpedo",
+                "Crew",
+                "Gunner",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Kihraxz Fighter": {
+        "blacksunace": {
+            "name": "Black Sun Ace",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 38,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "captainjostero": {
+            "name": "Captain Jostero",
+            "subtitle": "Aggressive Opportunist",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Missile",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "cartelmarauder": {
+            "name": "Cartel Marauder",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 37,
+            "slots": [
+                "Missile",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "graz": {
+            "name": "Graz",
+            "subtitle": "The Hunter",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Modification"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "talonbanecobra": {
+            "name": "Talonbane Cobra",
+            "subtitle": "Scourge of Tansarii Point",
+            "limited": 1,
+            "cost": 48,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "viktorhel": {
+            "name": "Viktor Hel",
+            "subtitle": "Storied Bounty Hunter",
+            "limited": 1,
+            "cost": 42,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Modification"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "blacksunbodyguard-wat1": {
+            "name": "Black Sun Bodyguard",
+            "subtitle": "Vaksai Pilot",
+            "limited": 2,
+            "cost": 40,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Lancer-class Pursuit Craft": {
+        "asajjventress": {
+            "name": "Asajj Ventress",
+            "subtitle": "Force of Her Own",
+            "limited": 1,
+            "cost": 66,
+            "slots": [
+                "Crew",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Title",
+                "Force Power"
+            ],
+            "keywords": [
+                "Bounty Hunter",
+                "Dark Side"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ketsuonyo": {
+            "name": "Ketsu Onyo",
+            "subtitle": "Black Sun Contractor",
+            "limited": 1,
+            "cost": 66,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter",
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sabinewren-lancerclasspursuitcraft": {
+            "name": "Sabine Wren",
+            "subtitle": "Artistic Saboteur",
+            "limited": 1,
+            "cost": 56,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter",
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "shadowporthunter": {
+            "name": "Shadowport Hunter",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 51,
+            "slots": [
+                "Crew",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "M12-L Kimogila Fighter": {
+        "cartelexecutioner": {
+            "name": "Cartel Executioner",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Torpedo",
+                "Missile",
+                "Astromech",
+                "Illicit",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dalanoberos": {
+            "name": "Dalan Oberos",
+            "subtitle": "Returned from the Grave",
+            "limited": 1,
+            "cost": 42,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Torpedo",
+                "Missile",
+                "Astromech",
+                "Illicit",
+                "Modification"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "toranikulda": {
+            "name": "Torani Kulda",
+            "subtitle": "Rodian Freelancer",
+            "limited": 1,
+            "cost": 47,
+            "slots": [
+                "Talent",
+                "Talent",
+                "Torpedo",
+                "Missile",
+                "Astromech",
+                "Illicit",
+                "Modification"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "M3-A Interceptor": {
+        "cartelspacer": {
+            "name": "Cartel Spacer",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 26,
+            "slots": [
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "genesisred": {
+            "name": "Genesis Red",
+            "subtitle": "Tansarii Point Crime Lord",
+            "limited": 1,
+            "cost": 31,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "inaldra": {
+            "name": "Inaldra",
+            "subtitle": "Tansarii Point Boss",
+            "limited": 1,
+            "cost": 27,
+            "slots": [
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "laetinashera": {
+            "name": "Laetin A’shera",
+            "subtitle": "Car’das Enforcer",
+            "limited": 1,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "quinnjast": {
+            "name": "Quinn Jast",
+            "subtitle": "Fortune Seeker",
+            "limited": 1,
+            "cost": 28,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "serissu": {
+            "name": "Serissu",
+            "subtitle": "Flight Instructor",
+            "limited": 1,
+            "cost": 40,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sunnybounder": {
+            "name": "Sunny Bounder",
+            "subtitle": "Incurable Optimist",
+            "limited": 1,
+            "cost": 27,
+            "slots": [
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "tansariipointveteran": {
+            "name": "Tansarii Point Veteran",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 28,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "g4rgorvm": {
+            "name": "G4R-G0R V/M",
+            "subtitle": "Tilted Droid",
+            "limited": 1,
+            "cost": 25,
+            "slots": [
+                "Modification"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Modified TIE/ln Fighter": {
+        "ahhav": {
+            "name": "Ahhav",
+            "subtitle": "Vengeful Survivor",
+            "limited": 1,
+            "cost": 27,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "captainseevor": {
+            "name": "Captain Seevor",
+            "subtitle": "Noisy Nuisance",
+            "limited": 1,
+            "cost": 28,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "foremanproach": {
+            "name": "Foreman Proach",
+            "subtitle": "Slave Driver",
+            "limited": 1,
+            "cost": 27,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "miningguildsurveyor": {
+            "name": "Mining Guild Surveyor",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 23,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "overseeryushyn": {
+            "name": "Overseer Yushyn",
+            "subtitle": "Overbearing Boss",
+            "limited": 1,
+            "cost": 22,
+            "slots": [
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "miningguildsentry": {
+            "name": "Mining Guild Sentry",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 22,
+            "slots": [
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lapin": {
+            "name": "Lapin",
+            "subtitle": "Stickler for Details",
+            "limited": 1,
+            "cost": 24,
+            "slots": [
+                "Modification"
+            ],
+            "keywords": [
+                "TIE"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Quadrijet Transfer Spacetug": {
+        "constablezuvio": {
+            "name": "Constable Zuvio",
+            "subtitle": "Missing Sheriff of Niima Outpost",
+            "limited": 1,
+            "cost": 30,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "jakkugunrunner": {
+            "name": "Jakku Gunrunner",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 28,
+            "slots": [
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sarcoplank": {
+            "name": "Sarco Plank",
+            "subtitle": "The Scavenger",
+            "limited": 1,
+            "cost": 29,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "unkarplutt": {
+            "name": "Unkar Plutt",
+            "subtitle": "Miserly Portion Master",
+            "limited": 1,
+            "cost": 29,
+            "slots": [
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Tech"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Rogue-class Starfighter": {
+        "durge": {
+            "name": "Durge",
+            "subtitle": "Hard to Kill",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Cannon",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "cadbane": {
+            "name": "Cad Bane",
+            "subtitle": "Infamous Bounty Hunter",
+            "limited": 1,
+            "cost": 40,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Cannon",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "viktorhel-rogueclassstarfighter": {
+            "name": "Viktor Hel",
+            "subtitle": "Storied Bounty Hunter",
+            "limited": 1,
+            "cost": 39,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Cannon",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "nomlumb-rogueclassstarfighter": {
+            "name": "Nom Lumb",
+            "subtitle": "Laughing Bandit",
+            "limited": 1,
+            "cost": 35,
+            "slots": [
+                "Cannon",
+                "Cannon",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "outerrimhunter": {
+            "name": "Outer Rim Hunter",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 35,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Cannon",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Scurrg H-6 bomber": {
+        "captainnym": {
+            "name": "Captain Nym",
+            "subtitle": "Captain of the Lok Revenants",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Crew",
+                "Device",
+                "Device",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lokrevenant": {
+            "name": "Lok Revenant",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 42,
+            "slots": [
+                "Turret",
+                "Crew",
+                "Device",
+                "Device",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "solsixxa": {
+            "name": "Sol Sixxa",
+            "subtitle": "Cunning Commander",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Talent",
+                "Turret",
+                "Crew",
+                "Device",
+                "Device",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "ST-70 Assault Ship": {
+        "themandalorian": {
+            "name": "The Mandalorian",
+            "subtitle": "Din Djarin",
+            "limited": 1,
+            "cost": 49,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Crew",
+                "Gunner",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Mandalorian",
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "q90": {
+            "name": "Q9-0",
+            "subtitle": "Zero",
+            "limited": 1,
+            "cost": 50,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Crew",
+                "Gunner",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "guildbountyhunter": {
+            "name": "Guild Bounty Hunter",
+            "subtitle": "Blaster for Hire",
+            "limited": 2,
+            "cost": 46,
+            "slots": [
+                "Crew",
+                "Crew",
+                "Gunner",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "outerrimenforcer": {
+            "name": "Outer Rim Enforcer",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 45,
+            "slots": [
+                "Crew",
+                "Crew",
+                "Gunner",
+                "Illicit",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "StarViper-class Attack Platform": {
+        "blacksunassassin": {
+            "name": "Black Sun Assassin",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 45,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Torpedo",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "blacksunenforcer": {
+            "name": "Black Sun Enforcer",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 42,
+            "slots": [
+                "Tech",
+                "Torpedo",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dalanoberos-starviperclassattackplatform": {
+            "name": "Dalan Oberos",
+            "subtitle": "Elite Bounty Hunter",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Torpedo",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "guri": {
+            "name": "Guri",
+            "subtitle": "Prince Xizor’s Bodyguard",
+            "limited": 1,
+            "cost": 59,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Torpedo",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "princexizor": {
+            "name": "Prince Xizor",
+            "subtitle": "Black Sun Kingpin",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Tech",
+                "Torpedo",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Trident-Class Assault Ship": {
+        "lawlesspirates": {
+            "name": "Lawless Pirates",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 85,
+            "slots": [
+                "Command",
+                "Torpedo",
+                "Hardpoint",
+                "Hardpoint",
+                "Crew",
+                "Crew",
+                "Gunner",
+                "Team",
+                "Cargo",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "Yes"
+        }
+    },
+    "YV-666 Light Freighter": {
+        "bossk": {
+            "name": "Bossk",
+            "subtitle": "Fearsome Hunter",
+            "limited": 1,
+            "cost": 63,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Bounty Hunter",
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "lattsrazzi": {
+            "name": "Latts Razzi",
+            "subtitle": "Martial Artist",
+            "limited": 1,
+            "cost": 53,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Bounty Hunter",
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "moraloeval": {
+            "name": "Moralo Eval",
+            "subtitle": "Criminal Mastermind",
+            "limited": 1,
+            "cost": 62,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "trandoshanslaver": {
+            "name": "Trandoshan Slaver",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 51,
+            "slots": [
+                "Cannon",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "doctoraphra": {
+            "name": "Doctor Aphra",
+            "subtitle": "Professional Disaster Zone",
+            "limited": 1,
+            "cost": 53,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title",
+                "Gunner"
+            ],
+            "keywords": [
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "YT-2400 Light Freighter (2023)": {
+        "dashrendar-swz103-sl-scumandvillainy": {
+            "name": "Dash Rendar",
+            "subtitle": "In it for Himself",
+            "limited": 1,
+            "cost": 88,
+            "slots": [],
+            "keywords": [
+                "Droid",
+                "Freighter"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "mercenary-swz103",
+                "seekermissiles-swz103",
+                "leebo-swz103",
+                "outrider"
+            ]
+        },
+        "dashrendar-swz103-lsl-scumandvillainy": {
+            "name": "Dash Rendar",
+            "subtitle": "In it for Himself",
+            "limited": 1,
+            "cost": 74,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Crew",
+                "Crew",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Droid",
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "leebo-swz103-sl-scumandvillainy": {
+            "name": "“Leebo”",
+            "subtitle": "He Thinks He's Funny",
+            "limited": 1,
+            "cost": 83,
+            "slots": [],
+            "keywords": [
+                "Droid",
+                "Freighter"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "efficientprocessing-swz103",
+                "seekermissiles-swz103",
+                "outrider"
+            ]
+        },
+        "leebo-swz103-lsl-scumandvillainy": {
+            "name": "“Leebo”",
+            "subtitle": "He Thinks He's Funny",
+            "limited": 1,
+            "cost": 69,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Missile",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Droid",
+                "Freighter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Z-95-AF4 Headhunter": {
+        "binayrepirate": {
+            "name": "Binayre Pirate",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 22,
+            "slots": [
+                "Missile",
+                "Illicit",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "blacksunsoldier": {
+            "name": "Black Sun Soldier",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 23,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Illicit",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "kaatoleeachos": {
+            "name": "Kaa'to Leeachos",
+            "subtitle": "Imposing Marauder",
+            "limited": 1,
+            "cost": 22,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Illicit",
+                "Modification"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ndrusuhlak": {
+            "name": "N’dru Suhlak",
+            "subtitle": "Hunt Saboteur",
+            "limited": 1,
+            "cost": 27,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Illicit",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "nashtahpup": {
+            "name": "Nashtah Pup",
+            "subtitle": "Contingency Plan",
+            "limited": 1,
+            "cost": 4,
+            "slots": [
+                "Missile",
+                "Illicit",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "bossk-z95af4headhunter": {
+            "name": "Bossk",
+            "subtitle": "Fearsome Hunter",
+            "limited": 1,
+            "cost": 25,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Illicit",
+                "Modification"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    }
+}

--- a/X2PO/dec2025/separatistalliance.json
+++ b/X2PO/dec2025/separatistalliance.json
@@ -1,0 +1,1557 @@
+{
+    "Vulture-class Droid Fighter": {
+        "tradefederationdrone": {
+            "name": "Trade Federation Drone",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 21,
+            "slots": [
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "precisehunter": {
+            "name": "Precise Hunter",
+            "subtitle": "Pinpoint Protocols",
+            "limited": 3,
+            "cost": 23,
+            "slots": [
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "haorchallprototype": {
+            "name": "Haor Chall Prototype",
+            "subtitle": "Xi Char Offering",
+            "limited": 2,
+            "cost": 22,
+            "slots": [
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dfs081": {
+            "name": "DFS-081",
+            "subtitle": "Preservation Programming",
+            "limited": 1,
+            "cost": 22,
+            "slots": [
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "separatistdrone": {
+            "name": "Separatist Drone",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 22,
+            "slots": [
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dfs311": {
+            "name": "DFS-311",
+            "subtitle": "Scouting Drone",
+            "limited": 1,
+            "cost": 23,
+            "slots": [
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dfs081-siegeofcoruscant": {
+            "name": "DFS-081",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 28,
+            "slots": [],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "discordmissiles",
+                "contingencyprotocol-siegeofcoruscant",
+                "strutlockoverride-siegeofcoruscant"
+            ]
+        },
+        "dfs081-siegeofcoruscant-lsl": {
+            "name": "DFS-081",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 23,
+            "slots": [
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dfs311-siegeofcoruscant": {
+            "name": "DFS-311",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 28,
+            "slots": [],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "discordmissiles",
+                "contingencyprotocol-siegeofcoruscant",
+                "strutlockoverride-siegeofcoruscant"
+            ]
+        },
+        "dfs311-siegeofcoruscant-lsl": {
+            "name": "DFS-311",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 23,
+            "slots": [
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "haorchallprototype-siegeofcoruscant": {
+            "name": "Haor Chall Prototype",
+            "subtitle": "Siege of Coruscant",
+            "limited": 2,
+            "cost": 25,
+            "slots": [],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "ionmissiles",
+                "contingencyprotocol-siegeofcoruscant",
+                "strutlockoverride-siegeofcoruscant"
+            ]
+        },
+        "haorchallprototype-siegeofcoruscant-lsl": {
+            "name": "Haor Chall Prototype",
+            "subtitle": "Siege of Coruscant",
+            "limited": 2,
+            "cost": 22,
+            "slots": [
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "theironassembler": {
+            "name": "The Iron Assembler",
+            "subtitle": "Scintilla Scavenger",
+            "limited": 1,
+            "cost": 22,
+            "slots": [
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "kelrodoaiholdout": {
+            "name": "Kelrodo-Ai Holdout",
+            "subtitle": "Separatist Stalwart",
+            "limited": 3,
+            "cost": 22,
+            "slots": [
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "00muplinkprototype-wat1": {
+            "name": "00M Uplink Prototype",
+            "subtitle": "Second-in-Command",
+            "limited": 1,
+            "cost": 23,
+            "slots": [
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dfs420-wat1": {
+            "name": "DFS-420",
+            "subtitle": "Marcan Deployer",
+            "limited": 1,
+            "cost": 24,
+            "slots": [
+                "Talent",
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "C-ROC Cruiser": {
+        "separatistprivateers": {
+            "name": "Separatist Privateers",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 63,
+            "slots": [
+                "Command",
+                "Hardpoint",
+                "Crew",
+                "Crew",
+                "Tactical Relay",
+                "Team",
+                "Cargo",
+                "Device",
+                "Configuration"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "Yes"
+        }
+    },
+    "Belbullab-22 Starfighter": {
+        "generalgrievous": {
+            "name": "General Grievous",
+            "subtitle": "Ambitious Cyborg",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Title",
+                "Tactical Relay"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "wattambor": {
+            "name": "Wat Tambor",
+            "subtitle": "Techno Union Foreman",
+            "limited": 1,
+            "cost": 39,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Title",
+                "Tactical Relay"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "feethanottrawautopilot": {
+            "name": "Feethan Ottraw Autopilot",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 34,
+            "slots": [
+                "Modification",
+                "Title",
+                "Tactical Relay"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "captainsear": {
+            "name": "Captain Sear",
+            "subtitle": "Kage Infiltrator",
+            "limited": 1,
+            "cost": 44,
+            "slots": [
+                "Modification",
+                "Title",
+                "Tactical Relay"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "skakoanace": {
+            "name": "Skakoan Ace",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 37,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Title",
+                "Tactical Relay"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "halliobas-wat1": {
+            "name": "Hallio Bas",
+            "subtitle": "Skakoan Guide",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Talent",
+                "Modification",
+                "Title",
+                "Tactical Relay"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Sith Infiltrator": {
+        "darthmaul": {
+            "name": "Darth Maul",
+            "subtitle": "Sith Assassin",
+            "limited": 1,
+            "cost": 62,
+            "slots": [
+                "Cannon",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Device",
+                "Modification",
+                "Title",
+                "Force Power",
+                "Tactical Relay"
+            ],
+            "keywords": [
+                "Dark Side",
+                "Sith"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "countdooku": {
+            "name": "Count Dooku",
+            "subtitle": "Darth Tyranus",
+            "limited": 1,
+            "cost": 60,
+            "slots": [
+                "Cannon",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Device",
+                "Modification",
+                "Title",
+                "Force Power",
+                "Tactical Relay"
+            ],
+            "keywords": [
+                "Dark Side",
+                "Sith"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "darkcourier": {
+            "name": "Dark Courier",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 45,
+            "slots": [
+                "Cannon",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Device",
+                "Modification",
+                "Title",
+                "Tactical Relay"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "066": {
+            "name": "0-66",
+            "subtitle": "Sinister Automaton",
+            "limited": 1,
+            "cost": 46,
+            "slots": [
+                "Talent",
+                "Torpedo",
+                "Cannon",
+                "Crew",
+                "Crew",
+                "Tactical Relay",
+                "Device",
+                "Title",
+                "Modification"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "countdooku-siegeofcoruscant": {
+            "name": "Count Dooku",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 75,
+            "slots": [],
+            "keywords": [
+                "Dark Side",
+                "Sith"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "malice",
+                "roilinganger-siegeofcoruscant",
+                "scimitar"
+            ]
+        },
+        "countdooku-siegeofcoruscant-lsl": {
+            "name": "Count Dooku",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 64,
+            "slots": [
+                "Cannon",
+                "Torpedo",
+                "Crew",
+                "Crew",
+                "Device",
+                "Modification",
+                "Title",
+                "Force Power",
+                "Tactical Relay"
+            ],
+            "keywords": [
+                "Dark Side",
+                "Sith"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Hyena-class Droid Bomber": {
+        "technounionbomber": {
+            "name": "Techno Union Bomber",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 26,
+            "slots": [
+                "Torpedo",
+                "Missile",
+                "Device",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "bombardmentdrone": {
+            "name": "Bombardment Drone",
+            "subtitle": "Time on Target",
+            "limited": 3,
+            "cost": 31,
+            "slots": [
+                "Sensor",
+                "Device",
+                "Device",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dbs404": {
+            "name": "DBS-404",
+            "subtitle": "Preservation Protocol Not Found",
+            "limited": 1,
+            "cost": 31,
+            "slots": [
+                "Torpedo",
+                "Missile",
+                "Device",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "baktoidprototype": {
+            "name": "Baktoid Prototype",
+            "subtitle": "Function over Form",
+            "limited": 2,
+            "cost": 25,
+            "slots": [
+                "Sensor",
+                "Missile",
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "separatistbomber": {
+            "name": "Separatist Bomber",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 28,
+            "slots": [
+                "Torpedo",
+                "Missile",
+                "Device",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dbs32c": {
+            "name": "DBS-32C",
+            "subtitle": "Droid Control Signal Relay",
+            "limited": 1,
+            "cost": 37,
+            "slots": [
+                "Sensor",
+                "Tactical Relay",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dbs32c-siegeofcoruscant": {
+            "name": "DBS-32C",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 38,
+            "slots": [],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "plasmatorpedoes",
+                "contingencyprotocol-siegeofcoruscant",
+                "strutlockoverride-siegeofcoruscant"
+            ]
+        },
+        "dbs32c-siegeofcoruscant-lsl": {
+            "name": "DBS-32C",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 30,
+            "slots": [
+                "Sensor",
+                "Tactical Relay",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dbs404-siegeofcoruscant": {
+            "name": "DBS-404",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 36,
+            "slots": [],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "advprotontorpedoes",
+                "contingencyprotocol-siegeofcoruscant",
+                "strutlockoverride-siegeofcoruscant"
+            ]
+        },
+        "dbs404-siegeofcoruscant-lsl": {
+            "name": "DBS-404",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 30,
+            "slots": [
+                "Torpedo",
+                "Missile",
+                "Device",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "baktoidprototype-siegeofcoruscant": {
+            "name": "Baktoid Prototype",
+            "subtitle": "Siege of Coruscant",
+            "limited": 2,
+            "cost": 34,
+            "slots": [],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "homingmissiles",
+                "contingencyprotocol-siegeofcoruscant",
+                "strutlockoverride-siegeofcoruscant"
+            ]
+        },
+        "baktoidprototype-siegeofcoruscant-lsl": {
+            "name": "Baktoid Prototype",
+            "subtitle": "Siege of Coruscant",
+            "limited": 2,
+            "cost": 25,
+            "slots": [
+                "Sensor",
+                "Missile",
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Nantex-class Starfighter": {
+        "stalgasinhiveguard": {
+            "name": "Stalgasin Hive Guard",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 33,
+            "slots": [
+                "Talent"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "sunfac": {
+            "name": "Sun Fac",
+            "subtitle": "Archduke’s Enforcer",
+            "limited": 1,
+            "cost": 43,
+            "slots": [
+                "Talent",
+                "Talent"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "berwerkret": {
+            "name": "Berwer Kret",
+            "subtitle": "Hive Guard Captain",
+            "limited": 1,
+            "cost": 35,
+            "slots": [
+                "Talent",
+                "Talent"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "chertek": {
+            "name": "Chertek",
+            "subtitle": "Opportunistic Ace",
+            "limited": 1,
+            "cost": 36,
+            "slots": [
+                "Talent",
+                "Talent"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "gorgol": {
+            "name": "Gorgol",
+            "subtitle": "Handy Engineer",
+            "limited": 1,
+            "cost": 29,
+            "slots": [
+                "Talent",
+                "Modification"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "petranakiarenaace": {
+            "name": "Petranaki Arena Ace",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 36,
+            "slots": [
+                "Talent",
+                "Talent"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Droid Tri-Fighter": {
+        "dist81": {
+            "name": "DIS-T81",
+            "subtitle": "Clever Circuits",
+            "limited": 1,
+            "cost": 36,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "phlacarphoccprototype": {
+            "name": "Phlac-Arphocc Prototype",
+            "subtitle": "Predictive Analysis Protocol",
+            "limited": 2,
+            "cost": 38,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "fearsomepredator": {
+            "name": "Fearsome Predator",
+            "subtitle": "Fixated Pursuit",
+            "limited": 3,
+            "cost": 35,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dis347": {
+            "name": "DIS-347",
+            "subtitle": "Target Acquired",
+            "limited": 1,
+            "cost": 35,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "separatistinterceptor": {
+            "name": "Separatist Interceptor",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 35,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "colicoidinterceptor": {
+            "name": "Colicoid Interceptor",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 34,
+            "slots": [
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dis347-siegeofcoruscant": {
+            "name": "DIS-347",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 40,
+            "slots": [],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "marksmanship",
+                "afterburners",
+                "contingencyprotocol-siegeofcoruscant"
+            ]
+        },
+        "dis347-siegeofcoruscant-lsl": {
+            "name": "DIS-347",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 35,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dist81-siegeofcoruscant": {
+            "name": "DIS-T81",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 48,
+            "slots": [],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "outmaneuver",
+                "afterburners",
+                "contingencyprotocol-siegeofcoruscant"
+            ]
+        },
+        "dist81-siegeofcoruscant-lsl": {
+            "name": "DIS-T81",
+            "subtitle": "Siege of Coruscant",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "phlacarphoccprototype-siegeofcoruscant": {
+            "name": "Phlac-Arphocc Prototype",
+            "subtitle": "Siege of Coruscant",
+            "limited": 2,
+            "cost": 50,
+            "slots": [],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "No",
+            "wildspace": "Yes",
+            "epic": "Yes",
+            "standardLoadout": [
+                "afterburners",
+                "contingencyprotocol-siegeofcoruscant",
+                "evasionsequence7-siegeofcoruscant"
+            ]
+        },
+        "phlacarphoccprototype-siegeofcoruscant-lsl": {
+            "name": "Phlac-Arphocc Prototype",
+            "subtitle": "Siege of Coruscant",
+            "limited": 2,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "volandas": {
+            "name": "Volan Das",
+            "subtitle": "Impatient Invader",
+            "limited": 1,
+            "cost": 41,
+            "slots": [
+                "Talent",
+                "Sensor",
+                "Missile",
+                "Illicit",
+                "Modification",
+                "Configuration"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "HMP Droid Gunship": {
+        "dgs047": {
+            "name": "DGS-047",
+            "subtitle": "Adaptive Intelligence",
+            "limited": 1,
+            "cost": 38,
+            "slots": [
+                "Missile",
+                "Missile",
+                "Crew",
+                "Device",
+                "Modification",
+                "Configuration",
+                "Tactical Relay"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "baktoiddrone": {
+            "name": "Baktoid Drone",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 37,
+            "slots": [
+                "Missile",
+                "Missile",
+                "Crew",
+                "Device",
+                "Modification",
+                "Configuration",
+                "Tactical Relay"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "geonosianprototype": {
+            "name": "Geonosian Prototype",
+            "subtitle": "Devastation Protocols",
+            "limited": 2,
+            "cost": 38,
+            "slots": [
+                "Cannon",
+                "Cannon",
+                "Missile",
+                "Missile",
+                "Modification",
+                "Configuration",
+                "Tactical Relay"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "dgs286": {
+            "name": "DGS-286",
+            "subtitle": "Ambush Protocols",
+            "limited": 1,
+            "cost": 39,
+            "slots": [
+                "Missile",
+                "Missile",
+                "Crew",
+                "Device",
+                "Modification",
+                "Configuration",
+                "Tactical Relay"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "onderonoppressor": {
+            "name": "Onderon Oppressor",
+            "subtitle": "Atmospheric Attack Module",
+            "limited": 2,
+            "cost": 39,
+            "slots": [
+                "Missile",
+                "Missile",
+                "Crew",
+                "Device",
+                "Modification",
+                "Configuration",
+                "Tactical Relay"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "separatistpredator": {
+            "name": "Separatist Predator",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 38,
+            "slots": [
+                "Missile",
+                "Missile",
+                "Crew",
+                "Device",
+                "Modification",
+                "Configuration",
+                "Tactical Relay"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Trident-Class Assault Ship": {
+        "colicoiddestroyer": {
+            "name": "Colicoid Destroyer",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 85,
+            "slots": [
+                "Command",
+                "Torpedo",
+                "Hardpoint",
+                "Hardpoint",
+                "Crew",
+                "Crew",
+                "Gunner",
+                "Team",
+                "Cargo",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "No",
+            "wildspace": "No",
+            "epic": "Yes"
+        }
+    },
+    "Firespray-class Patrol Craft": {
+        "jangofett": {
+            "name": "Jango Fett",
+            "subtitle": "Simple Man",
+            "limited": 1,
+            "cost": 79,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Missile",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "zamwesell": {
+            "name": "Zam Wesell",
+            "subtitle": "Clawdite Changeling",
+            "limited": 1,
+            "cost": 83,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Missile",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "bobafett-firesprayclasspatrolcraft": {
+            "name": "Boba Fett",
+            "subtitle": "Survivor",
+            "limited": 1,
+            "cost": 66,
+            "slots": [
+                "Cannon",
+                "Missile",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "separatistracketeer": {
+            "name": "Separatist Racketeer",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 62,
+            "slots": [
+                "Cannon",
+                "Missile",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "aurrasing": {
+            "name": "Aurra Sing",
+            "subtitle": "Bane of the Jedi",
+            "limited": 1,
+            "cost": 75,
+            "slots": [
+                "Force Power",
+                "Cannon",
+                "Missile",
+                "Crew",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Dark Side",
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Rogue-class Starfighter": {
+        "durge-separatistalliance": {
+            "name": "Durge",
+            "subtitle": "On His Own Time",
+            "limited": 1,
+            "cost": 45,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Cannon",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "cadbane-separatistalliance": {
+            "name": "Cad Bane",
+            "subtitle": "Needs No Introduction",
+            "limited": 1,
+            "cost": 42,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Cannon",
+                "Illicit",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Bounty Hunter"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ig101": {
+            "name": "IG-101",
+            "subtitle": "Tenacious Bodyguard",
+            "limited": 1,
+            "cost": 39,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Cannon",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "magnaguardexecutioner": {
+            "name": "MagnaGuard Executioner",
+            "subtitle": "",
+            "limited": 0,
+            "cost": 37,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Cannon",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "magnaguardprotector": {
+            "name": "MagnaGuard Protector",
+            "subtitle": "Implacable Escort",
+            "limited": 2,
+            "cost": 39,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Cannon",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ig102": {
+            "name": "IG-102",
+            "subtitle": "Dueling Droid",
+            "limited": 1,
+            "cost": 39,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Cannon",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "ig111": {
+            "name": "IG-111",
+            "subtitle": "One Eye",
+            "limited": 1,
+            "cost": 37,
+            "slots": [
+                "Talent",
+                "Cannon",
+                "Cannon",
+                "Modification",
+                "Title"
+            ],
+            "keywords": [
+                "Droid"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    },
+    "Gauntlet Fighter": {
+        "bokatankryze-separatistalliance": {
+            "name": "Bo-Katan Kryze",
+            "subtitle": "Vizsla's Lieutenant",
+            "limited": 1,
+            "cost": 57,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Gunner",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Configuration",
+                "Title"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "previzsla": {
+            "name": "Pre Vizsla",
+            "subtitle": "Leader of Death Watch",
+            "limited": 1,
+            "cost": 61,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Gunner",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Configuration",
+                "Title"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        },
+        "deathwatchwarrior": {
+            "name": "Death Watch Warrior",
+            "subtitle": "Fanatical Adherent",
+            "limited": 0,
+            "cost": 53,
+            "slots": [
+                "Talent",
+                "Crew",
+                "Gunner",
+                "Device",
+                "Illicit",
+                "Modification",
+                "Configuration",
+                "Title"
+            ],
+            "keywords": [
+                "Mandalorian"
+            ],
+            "standard": "Yes",
+            "wildspace": "Yes",
+            "epic": "Yes"
+        }
+    }
+}

--- a/X2PO/dec2025/upgrades.json
+++ b/X2PO/dec2025/upgrades.json
@@ -1,0 +1,9462 @@
+{
+    "chopper": {
+        "name": "“Chopper”",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "genius": {
+        "name": "“Genius”",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r2astromech": {
+        "name": "R2 Astromech",
+        "cost": {
+            "variable": "agility",
+            "values": {
+                "0": 2,
+                "1": 2,
+                "2": 4,
+                "3": 8
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r2d2": {
+        "name": "R2-D2",
+        "cost": {
+            "variable": "agility",
+            "values": {
+                "0": 3,
+                "1": 4,
+                "2": 7,
+                "3": 11
+            }
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r3astromech": {
+        "name": "R3 Astromech",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r4astromech": {
+        "name": "R4 Astromech",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Small"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r5astromech": {
+        "name": "R5 Astromech",
+        "cost": {
+            "variable": "agility",
+            "values": {
+                "0": 1,
+                "1": 2,
+                "2": 3,
+                "3": 4
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r5d8": {
+        "name": "R5-D8",
+        "cost": {
+            "variable": "agility",
+            "values": {
+                "0": 3,
+                "1": 4,
+                "2": 4,
+                "3": 6
+            }
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r5p8": {
+        "name": "R5-P8",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r5tk": {
+        "name": "R5-TK",
+        "cost": {
+            "value": 0
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r5x3": {
+        "name": "R5-X3",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r2ha": {
+        "name": "R2-HA",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "bb8": {
+        "name": "BB-8",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 2,
+                "1": 2,
+                "2": 3,
+                "3": 4,
+                "4": 4,
+                "5": 5,
+                "6": 6,
+                "7": 6,
+                "8": 6
+            }
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "bbastromech": {
+        "name": "BB Astromech",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 1,
+                "1": 1,
+                "2": 2,
+                "3": 3,
+                "4": 3,
+                "5": 4,
+                "6": 5,
+                "7": 5,
+                "8": 5
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "m9g8": {
+        "name": "M9-G8",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r2c4": {
+        "name": "R2-C4",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r4pastromech": {
+        "name": "R4-P Astromech",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r4p17": {
+        "name": "R4-P17",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r4p44": {
+        "name": "R4-P44",
+        "cost": {
+            "value": 1
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r2a6": {
+        "name": "R2-A6",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "c110p": {
+        "name": "C1-10P",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r1j5": {
+        "name": "R1-J5",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "q7astromech": {
+        "name": "Q7 Astromech",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 2,
+                "1": 2,
+                "2": 2,
+                "3": 2,
+                "4": 3,
+                "5": 3,
+                "6": 3
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r2d2-republic": {
+        "name": "R2-D2",
+        "cost": {
+            "variable": "agility",
+            "values": {
+                "0": 2,
+                "1": 4,
+                "2": 6,
+                "3": 8
+            }
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r2d2-resistance": {
+        "name": "R2-D2",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r6d8": {
+        "name": "R6-D8",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r7a7": {
+        "name": "R7-A7",
+        "cost": {
+            "variable": "agility",
+            "values": {
+                "0": 3,
+                "1": 3,
+                "2": 3,
+                "3": 5
+            }
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "r4b11": {
+        "name": "R4-B11",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "watchfulastromech": {
+        "name": "Watchful Astromech",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "l4er5": {
+        "name": "L4E-R5",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ],
+                "action": {
+                    "type": "Rotate Arc"
+                }
+            }
+        ],
+        "slots": [
+            "Astromech"
+        ]
+    },
+    "heavylasercannon": {
+        "name": "Heavy Laser Cannon",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Cannon"
+        ]
+    },
+    "ioncannon": {
+        "name": "Ion Cannon",
+        "cost": {
+            "value": 6
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Cannon"
+        ]
+    },
+    "jammingbeam": {
+        "name": "Jamming Beam",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Cannon"
+        ]
+    },
+    "tractorbeam": {
+        "name": "Tractor Beam",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Cannon"
+        ]
+    },
+    "autoblasters": {
+        "name": "Autoblasters",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Cannon"
+        ]
+    },
+    "syncedlasercannons": {
+        "name": "Synced Laser Cannons",
+        "cost": {
+            "value": 7
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Cannon",
+            "Cannon"
+        ]
+    },
+    "protoncannons": {
+        "name": "Proton Cannons",
+        "cost": {
+            "value": 5
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Cannon",
+            "Cannon"
+        ]
+    },
+    "underslungblastercannon": {
+        "name": "Underslung Blaster Cannon",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Cannon"
+        ]
+    },
+    "adaptiveshields": {
+        "name": "Adaptive Shields",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Cargo"
+        ]
+    },
+    "boostedscanners": {
+        "name": "Boosted Scanners",
+        "cost": {
+            "value": 6
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Cargo"
+        ]
+    },
+    "optimizedpowercore": {
+        "name": "Optimized Power Core",
+        "cost": {
+            "value": 7
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Cargo"
+        ]
+    },
+    "tibannareserves": {
+        "name": "Tibanna Reserves",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Cargo"
+        ]
+    },
+    "agentoftheempire": {
+        "name": "Agent of the Empire",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Command"
+        ]
+    },
+    "dreadnoughthunter": {
+        "name": "Dreadnought Hunter",
+        "cost": {
+            "value": 3
+        },
+        "limited": 2,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Command"
+        ]
+    },
+    "firstorderelite": {
+        "name": "First Order Elite",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Command"
+        ]
+    },
+    "veteranwingleader": {
+        "name": "Veteran Wing Leader",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Command"
+        ]
+    },
+    "admiralozzel": {
+        "name": "Admiral Ozzel",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Command",
+            "Crew"
+        ]
+    },
+    "azmorigan": {
+        "name": "Azmorigan",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Command",
+            "Crew"
+        ]
+    },
+    "captainneeda": {
+        "name": "Captain Needa",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Command",
+            "Crew"
+        ]
+    },
+    "carlistrieekan": {
+        "name": "Carlist Rieekan",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Command",
+            "Crew"
+        ]
+    },
+    "jandodonna": {
+        "name": "Jan Dodonna",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Command",
+            "Crew"
+        ]
+    },
+    "raymusantilles": {
+        "name": "Raymus Antilles",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Command",
+            "Crew"
+        ]
+    },
+    "stalwartcaptain": {
+        "name": "Stalwart Captain",
+        "cost": {
+            "value": 10
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Huge"
+                ]
+            }
+        ],
+        "slots": [
+            "Command",
+            "Crew"
+        ]
+    },
+    "strategiccommander": {
+        "name": "Strategic Commander",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Huge"
+                ]
+            }
+        ],
+        "slots": [
+            "Command",
+            "Crew"
+        ]
+    },
+    "jedicommander": {
+        "name": "Jedi Commander",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            },
+            {
+                "ships": [
+                    "delta7aethersprite",
+                    "eta2actis"
+                ]
+            }
+        ],
+        "slots": [
+            "Command"
+        ]
+    },
+    "b6bladewingprototype-command": {
+        "name": "B6 Blade Wing Prototype",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "asf01bwing"
+                ]
+            }
+        ],
+        "slots": [
+            "Command",
+            "Title"
+        ]
+    },
+    "bounty": {
+        "name": "Bounty",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Command"
+        ]
+    },
+    "phoenixsquadron": {
+        "name": "Phoenix Squadron",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Command"
+        ]
+    },
+    "shadowwing": {
+        "name": "Shadow Wing",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Command"
+        ]
+    },
+    "skystrikeacademyclass": {
+        "name": "Skystrike Academy Class",
+        "cost": {
+            "value": 3
+        },
+        "limited": 2,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Command"
+        ]
+    },
+    "initforthemoney": {
+        "name": "In It For The Money",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "standardized": true
+            },
+            {
+                "non-limited": false
+            }
+        ],
+        "slots": [
+            "Command"
+        ]
+    },
+    "martuuk": {
+        "name": "Mar Tuuk",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            },
+            {
+                "sizes": [
+                    "Huge"
+                ]
+            }
+        ],
+        "slots": [
+            "Command",
+            "Crew"
+        ]
+    },
+    "rifftamson": {
+        "name": "Riff Tamson",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            },
+            {
+                "sizes": [
+                    "Huge"
+                ]
+            }
+        ],
+        "slots": [
+            "Command",
+            "Crew"
+        ]
+    },
+    "asajjventresscommand": {
+        "name": "Asajj Ventress",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance",
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "sizes": [
+                    "Huge"
+                ]
+            }
+        ],
+        "slots": [
+            "Command",
+            "Crew"
+        ]
+    },
+    "zealouscaptain": {
+        "name": "Zealous Captain",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Huge"
+                ]
+            }
+        ],
+        "slots": [
+            "Command",
+            "Crew"
+        ]
+    },
+    "hondoohnakacommand": {
+        "name": "Hondo Ohnaka",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Huge"
+                ]
+            }
+        ],
+        "slots": [
+            "Command",
+            "Crew"
+        ]
+    },
+    "generalgrievouscommand": {
+        "name": "General Grievous",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Huge"
+                ]
+            },
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Command",
+            "Crew"
+        ]
+    },
+    "combatboardingtube": {
+        "name": "Combat Boarding Tube",
+        "cost": {
+            "value": "0"
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "gauntletfighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Command",
+            "Configuration"
+        ]
+    },
+    "integratedsfoils": {
+        "name": "Integrated S-foils",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "t70xwing"
+                ]
+            }
+        ],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "os1arsenalloadout": {
+        "name": "Os-1 Arsenal Loadout",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "alphaclassstarwing"
+                ]
+            }
+        ],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "pivotwing": {
+        "name": "Pivot Wing",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "ut60duwing"
+                ]
+            }
+        ],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "swivelwing": {
+        "name": "Swivel Wing",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "gauntletfighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "servomotorsfoils": {
+        "name": "Servomotor S-foils",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "t65xwing"
+                ]
+            }
+        ],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "xg1assaultconfiguration": {
+        "name": "Xg-1 Assault Configuration",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "alphaclassstarwing"
+                ]
+            }
+        ],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "grapplingstruts": {
+        "name": "Grappling Struts",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "vultureclassdroidfighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "delta7b": {
+        "name": "Delta-7B",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 15,
+                "1": 15,
+                "2": 15,
+                "3": 15,
+                "4": 16,
+                "5": 18,
+                "6": 22
+            }
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": false,
+        "restrictions": [
+            {
+                "ships": [
+                    "delta7aethersprite"
+                ]
+            }
+        ],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "calibratedlasertargeting": {
+        "name": "Calibrated Laser Targeting",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 2,
+                "1": 2,
+                "2": 3,
+                "3": 4,
+                "4": 5,
+                "5": 6,
+                "6": 7
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "delta7aethersprite"
+                ]
+            }
+        ],
+        "slots": [
+            "Configuration",
+            "Modification"
+        ]
+    },
+    "landingstruts": {
+        "name": "Landing Struts",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "hyenaclassdroidbomber"
+                ]
+            }
+        ],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "corsairrefit": {
+        "name": "Corsair Refit",
+        "cost": {
+            "value": 6
+        },
+        "limited": 2,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "croccruiser"
+                ]
+            }
+        ],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "stabilizedsfoils": {
+        "name": "Stabilized S-foils",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "repulsorliftstabilizers": {
+        "name": "Repulsorlift Stabilizers",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "alpha3bbesh": {
+        "name": "Alpha-3B “Besh”",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "alpha3eesk": {
+        "name": "Alpha-3E “Esk”",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "interceptbooster": {
+        "name": "Intercept Booster",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "maneuverassistmgk300": {
+        "name": "Maneuver-Assist MGK-300",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "targetassistmgk300": {
+        "name": "Target-Assist MGK-300",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "sensitivecontrols": {
+        "name": "Sensitive Controls",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "shipAbility": [
+                    "Autothrusters"
+                ]
+            },
+            {
+                "standardized": true
+            }
+        ],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "tiedefenderelite": {
+        "name": "TIE Defender Elite",
+        "cost": {
+            "value": -8
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "ships": [
+                    "tieddefender"
+                ]
+            },
+            {
+                "standardized": true
+            }
+        ],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "vectoredcannonsrz1": {
+        "name": "Vectored Cannons (RZ-1)",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "shipAbility": [
+                    "Vectored Thrusters"
+                ]
+            },
+            {
+                "standardized": true
+            }
+        ],
+        "slots": [
+            "Configuration"
+        ]
+    },
+    "wartimeloadout": {
+        "name": "Wartime Loadout",
+        "cost": {
+            "value": 5
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "btanr2ywing"
+                ]
+            },
+            {
+                "standardized": true
+            }
+        ],
+        "slots": [
+            "Configuration",
+            "Modification"
+        ]
+    },
+    "enhancedjammingsuite": {
+        "name": "Enhanced Jamming Suite",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "tiewiwhispermodifiedinterceptor"
+                ]
+            }
+        ],
+        "slots": [
+            "Configuration",
+            "Tech"
+        ]
+    },
+    "chopper-crew": {
+        "name": "“Chopper”",
+        "cost": {
+            "value": 1
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "zeborrelios": {
+        "name": "“Zeb” Orrelios",
+        "cost": {
+            "value": 1
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "000": {
+        "name": "0-0-0",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ],
+                "names": [
+                    "Darth Vader"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "4lom": {
+        "name": "4-LOM",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "admiralsloane": {
+        "name": "Admiral Sloane",
+        "cost": {
+            "value": 18
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "agentkallus": {
+        "name": "Agent Kallus",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "bazemalbus": {
+        "name": "Baze Malbus",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "bobafett": {
+        "name": "Boba Fett",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "c3po": {
+        "name": "C-3PO",
+        "cost": {
+            "value": 7
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "cadbane": {
+        "name": "Cad Bane",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "captainphasma": {
+        "name": "Captain Phasma",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "cassianandor": {
+        "name": "Cassian Andor",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "chewbacca": {
+        "name": "Chewbacca",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "chewbacca-crew": {
+        "name": "Chewbacca",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "cienaree": {
+        "name": "Ciena Ree",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "action": {
+                    "type": "Coordinate"
+                }
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "cikatrovizago": {
+        "name": "Cikatro Vizago",
+        "cost": {
+            "value": 1
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "darthvader": {
+        "name": "Darth Vader",
+        "cost": {
+            "value": 16
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "deathtroopers": {
+        "name": "Death Troopers",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew",
+            "Crew"
+        ]
+    },
+    "directorkrennic": {
+        "name": "Director Krennic",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "emperorpalpatine": {
+        "name": "Emperor Palpatine",
+        "cost": {
+            "value": 12
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew",
+            "Crew"
+        ]
+    },
+    "freelanceslicer": {
+        "name": "Freelance Slicer",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "generalhux": {
+        "name": "General Hux",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "gnkgonkdroid": {
+        "name": "GNK “Gonk” Droid",
+        "cost": {
+            "value": 5
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "grandinquisitor": {
+        "name": "Grand Inquisitor",
+        "cost": {
+            "value": 13
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "grandmofftarkin": {
+        "name": "Grand Moff Tarkin",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "action": {
+                    "type": "Lock"
+                }
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "herasyndulla": {
+        "name": "Hera Syndulla",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "ig88d": {
+        "name": "IG-88D",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "isbslicer": {
+        "name": "ISB Slicer",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "informant": {
+        "name": "Informant",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "jabbathehutt": {
+        "name": "Jabba the Hutt",
+        "cost": {
+            "value": 11
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew",
+            "Crew"
+        ]
+    },
+    "jynerso": {
+        "name": "Jyn Erso",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "kananjarrus": {
+        "name": "Kanan Jarrus",
+        "cost": {
+            "value": 12
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "ketsuonyo": {
+        "name": "Ketsu Onyo",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "kyloren": {
+        "name": "Kylo Ren",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "l337": {
+        "name": "L3-37",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "landocalrissian-crew": {
+        "name": "Lando Calrissian",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "landocalrissian": {
+        "name": "Lando Calrissian",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "lattsrazzi": {
+        "name": "Latts Razzi",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "leiaorgana": {
+        "name": "Leia Organa",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "magvayarro": {
+        "name": "Magva Yarro",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "maul": {
+        "name": "Maul",
+        "cost": {
+            "value": 11
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ],
+                "names": [
+                    "Ezra Bridger"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "ministertua": {
+        "name": "Minister Tua",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "moffjerjerrod": {
+        "name": "Moff Jerjerrod",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "action": {
+                    "type": "Coordinate"
+                }
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "niennunb": {
+        "name": "Nien Nunb",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "novicetechnician": {
+        "name": "Novice Technician",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "perceptivecopilot": {
+        "name": "Perceptive Copilot",
+        "cost": {
+            "value": 8
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "pettyofficerthanisson": {
+        "name": "Petty Officer Thanisson",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "qira": {
+        "name": "Qi'ra",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "r2d2-crew": {
+        "name": "R2-D2",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "sabinewren": {
+        "name": "Sabine Wren",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "sawgerrera": {
+        "name": "Saw Gerrera",
+        "cost": {
+            "value": 9
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "seasonednavigator": {
+        "name": "Seasoned Navigator",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 2,
+                "1": 3,
+                "2": 4,
+                "3": 5,
+                "4": 6,
+                "5": 7,
+                "6": 8,
+                "7": 9,
+                "8": 10
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "seventhsister": {
+        "name": "Seventh Sister",
+        "cost": {
+            "value": 10
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "supremeleadersnoke": {
+        "name": "Supreme Leader Snoke",
+        "cost": {
+            "value": 13
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew",
+            "Crew"
+        ]
+    },
+    "tacticalofficer": {
+        "name": "Tactical Officer",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "action": {
+                    "type": "Coordinate",
+                    "difficulty": "Red"
+                }
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "tobiasbeckett": {
+        "name": "Tobias Beckett",
+        "cost": {
+            "value": 1
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "unkarplutt": {
+        "name": "Unkar Plutt",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "zuckuss": {
+        "name": "Zuckuss",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "c3po-crew": {
+        "name": "C-3PO",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "hansolo-crew": {
+        "name": "Han Solo",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "chewbacca-crew-swz19": {
+        "name": "Chewbacca",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "rosetico": {
+        "name": "Rose Tico",
+        "cost": {
+            "value": 9
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "chancellorpalpatine": {
+        "name": "Chancellor Palpatine",
+        "cost": {
+            "value": 14
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic",
+                    "separatistalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "countdooku": {
+        "name": "Count Dooku",
+        "cost": {
+            "value": 14
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "generalgrievous": {
+        "name": "General Grievous",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "amilynholdo": {
+        "name": "Amilyn Holdo",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "ga97": {
+        "name": "GA-97",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "kaydelconnix": {
+        "name": "Kaydel Connix",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "korrsella": {
+        "name": "Korr Sella",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "larmadacy": {
+        "name": "Larma D'Acy",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "leiaorgana-resistance": {
+        "name": "Leia Organa",
+        "cost": {
+            "value": 16
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew",
+            "Crew"
+        ]
+    },
+    "pz4co": {
+        "name": "PZ-4CO",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "c3po-republic": {
+        "name": "C-3PO",
+        "cost": {
+            "value": 7
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "aaylasecura": {
+        "name": "Aayla Secura",
+        "cost": {
+            "value": 12
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "agentterex": {
+        "name": "Agent Terex",
+        "cost": {
+            "value": 7
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "k2so": {
+        "name": "K-2SO",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "plokoon": {
+        "name": "Plo Koon",
+        "cost": {
+            "variable": "size",
+            "values": {
+                "Small": 8,
+                "Medium": 8,
+                "Large": 9,
+                "Huge": 15
+            }
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "torynfarr": {
+        "name": "Toryn Farr",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "kitfisto": {
+        "name": "Kit Fisto",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "yoda": {
+        "name": "Yoda",
+        "cost": {
+            "value": 11
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "fives": {
+        "name": "“Fives”",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "wolfpack": {
+        "name": "Wolfpack",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew",
+            "Gunner"
+        ]
+    },
+    "commandermalarus": {
+        "name": "Commander Malarus",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "ghostcompany": {
+        "name": "Ghost Company",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew",
+            "Gunner"
+        ]
+    },
+    "commanderpyre": {
+        "name": "Commander Pyre",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "hondoohnaka": {
+        "name": "Hondo Ohnaka",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "jangofett": {
+        "name": "Jango Fett",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy",
+                    "separatistalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "zamwesell": {
+        "name": "Zam Wesell",
+        "cost": {
+            "value": 11
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy",
+                    "separatistalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "gamutkey": {
+        "name": "Gamut Key",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "protectorategleb": {
+        "name": "Protectorate Gleb",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy",
+                    "galacticempire",
+                    "firstorder"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "themandalorian": {
+        "name": "The Mandalorian",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "thechild": {
+        "name": "The Child",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire",
+                    "rebelalliance",
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "ig11": {
+        "name": "IG-11",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "greefkarga": {
+        "name": "Greef Karga",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "kuiil": {
+        "name": "Kuiil",
+        "cost": {
+            "variable": "size",
+            "values": {
+                "Small": 3,
+                "Medium": 6,
+                "Large": 8,
+                "Huge": 15
+            }
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "pelimotto": {
+        "name": "Peli Motto",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "sizes": [
+                    "Medium",
+                    "Large"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "primeministeralmec": {
+        "name": "Prime Minister Almec",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy",
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "rookkast": {
+        "name": "Rook Kast",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "obiwankenobi": {
+        "name": "Obi-Wan Kenobi",
+        "cost": {
+            "value": 9
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "bokatankryze": {
+        "name": "Bo-Katan Kryze",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic",
+                    "separatistalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "bokatankryze-rebel-scum": {
+        "name": "Bo-Katan Kryze",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy",
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "korkiekryze": {
+        "name": "Korkie Kryze",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "satinekryze": {
+        "name": "Satine Kryze",
+        "cost": {
+            "value": 7
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "talmerrik": {
+        "name": "Tal Merrik",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "savageopress": {
+        "name": "Savage Opress",
+        "cost": {
+            "value": 10
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy",
+                    "separatistalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "fennrau": {
+        "name": "Fenn Rau",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy",
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "garsaxon": {
+        "name": "Gar Saxon",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "previzsla": {
+        "name": "Pre Vizsla",
+        "cost": {
+            "value": 7
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy",
+                    "separatistalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "tristanwren": {
+        "name": "Tristan Wren",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ],
+                "names": [
+                    "Gar Saxon"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "ursawren": {
+        "name": "Ursa Wren",
+        "cost": {
+            "value": 7
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "captainhark": {
+        "name": "Captain Hark",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "ahsokatano-crew": {
+        "name": "Ahsoka Tano",
+        "cost": {
+            "value": 10
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy",
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "maul-crew": {
+        "name": "Maul",
+        "cost": {
+            "value": 10
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew",
+            "Crew"
+        ]
+    },
+    "clanwrencommandos": {
+        "name": "Clan Wren Commandos",
+        "cost": {
+            "value": 10
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            },
+            {
+                "sizes": [
+                    "Medium",
+                    "Large",
+                    "Huge"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew",
+            "Crew"
+        ]
+    },
+    "imperialsupercommandos": {
+        "name": "Imperial Super Commandos",
+        "cost": {
+            "value": 10
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "sizes": [
+                    "Medium",
+                    "Large",
+                    "Huge"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew",
+            "Crew"
+        ]
+    },
+    "mandaloriansupercommandos": {
+        "name": "Mandalorian Super Commandos",
+        "cost": {
+            "value": 10
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "sizes": [
+                    "Medium",
+                    "Large",
+                    "Huge"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew",
+            "Crew"
+        ]
+    },
+    "niteowlcommandos": {
+        "name": "Nite Owl Commandos",
+        "cost": {
+            "value": 10
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            },
+            {
+                "sizes": [
+                    "Medium",
+                    "Large",
+                    "Huge"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew",
+            "Crew"
+        ]
+    },
+    "deathwatchcommandos": {
+        "name": "Death Watch Commandos",
+        "cost": {
+            "value": 10
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            },
+            {
+                "sizes": [
+                    "Medium",
+                    "Large",
+                    "Huge"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew",
+            "Crew"
+        ]
+    },
+    "leebo-rsl": {
+        "name": "Leebo",
+        "cost": {
+            "value": 1
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": true,
+        "epic": false,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy",
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Crew"
+        ]
+    },
+    "bombletgenerator": {
+        "name": "Bomblet Generator",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Device",
+            "Device"
+        ]
+    },
+    "blazerbomb": {
+        "name": "Blazer Bomb",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Device"
+        ]
+    },
+    "connernets": {
+        "name": "Conner Nets",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Device"
+        ]
+    },
+    "protonbombs": {
+        "name": "Proton Bombs",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Device"
+        ]
+    },
+    "proximitymines": {
+        "name": "Proximity Mines",
+        "cost": {
+            "value": 6
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Device"
+        ]
+    },
+    "seismiccharges": {
+        "name": "Seismic Charges",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Device"
+        ]
+    },
+    "drk1probedroids": {
+        "name": "DRK-1 Probe Droids",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Device"
+        ]
+    },
+    "electroprotonbomb": {
+        "name": "Electro-Proton Bomb",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "action": {
+                    "type": "Reload",
+                    "difficulty": "White"
+                }
+            }
+        ],
+        "slots": [
+            "Device",
+            "Modification"
+        ]
+    },
+    "clustermines": {
+        "name": "Cluster Mines",
+        "cost": {
+            "value": 6
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Device"
+        ]
+    },
+    "ionbombs": {
+        "name": "Ion Bombs",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Device"
+        ]
+    },
+    "concussionbombs": {
+        "name": "Concussion Bombs",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Device"
+        ]
+    },
+    "thermaldetonators": {
+        "name": "Thermal Detonators",
+        "cost": {
+            "value": 5
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Device"
+        ]
+    },
+    "heightenedperception": {
+        "name": "Heightened Perception",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Force Power"
+        ]
+    },
+    "instinctiveaim": {
+        "name": "Instinctive Aim",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Force Power"
+        ]
+    },
+    "sense": {
+        "name": "Sense",
+        "cost": {
+            "value": 7
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Force Power"
+        ]
+    },
+    "supernaturalreflexes": {
+        "name": "Supernatural Reflexes",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 4,
+                "1": 4,
+                "2": 4,
+                "3": 8,
+                "4": 16,
+                "5": 24,
+                "6": 32
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Small"
+                ]
+            }
+        ],
+        "slots": [
+            "Force Power"
+        ]
+    },
+    "brilliantevasion": {
+        "name": "Brilliant Evasion",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Force Power"
+        ]
+    },
+    "hate": {
+        "name": "Hate",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "force_side": [
+                    "dark"
+                ]
+            }
+        ],
+        "slots": [
+            "Force Power"
+        ]
+    },
+    "predictiveshot": {
+        "name": "Predictive Shot",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Force Power"
+        ]
+    },
+    "battlemeditation": {
+        "name": "Battle Meditation",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 2,
+                "1": 2,
+                "2": 2,
+                "3": 2,
+                "4": 3,
+                "5": 4,
+                "6": 6
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Force Power"
+        ]
+    },
+    "foresight": {
+        "name": "Foresight",
+        "cost": {
+            "value": 5
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Force Power"
+        ]
+    },
+    "precognitivereflexes": {
+        "name": "Precognitive Reflexes",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 3,
+                "1": 3,
+                "2": 3,
+                "3": 4,
+                "4": 7,
+                "5": 10,
+                "6": 13
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Small"
+                ]
+            }
+        ],
+        "slots": [
+            "Force Power"
+        ]
+    },
+    "extrememaneuvers": {
+        "name": "Extreme Maneuvers",
+        "cost": {
+            "value": 5
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Force Power"
+        ]
+    },
+    "compassion": {
+        "name": "Compassion",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "force_side": [
+                    "light"
+                ]
+            }
+        ],
+        "slots": [
+            "Force Power"
+        ]
+    },
+    "malice": {
+        "name": "Malice",
+        "cost": {
+            "value": 6
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "force_side": [
+                    "dark"
+                ]
+            }
+        ],
+        "slots": [
+            "Force Power"
+        ]
+    },
+    "shatteringshot": {
+        "name": "Shattering Shot",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Force Power"
+        ]
+    },
+    "patience": {
+        "name": "Patience",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "force_side": [
+                    "light"
+                ]
+            }
+        ],
+        "slots": [
+            "Force Power"
+        ]
+    },
+    "roilinganger-rsl": {
+        "name": "Roiling Anger",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": true,
+        "epic": false,
+        "restrictions": [
+            {
+                "force_side": [
+                    "dark"
+                ]
+            }
+        ],
+        "slots": [
+            "Force Power"
+        ]
+    },
+    "agilegunner": {
+        "name": "Agile Gunner",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "bt1": {
+        "name": "BT-1",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ],
+                "names": [
+                    "Darth Vader"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "bistan": {
+        "name": "Bistan",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "bossk": {
+        "name": "Bossk",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "dengar": {
+        "name": "Dengar",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "ezrabridger": {
+        "name": "Ezra Bridger",
+        "cost": {
+            "value": 10
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "fifthbrother": {
+        "name": "Fifth Brother",
+        "cost": {
+            "value": 12
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "greedo": {
+        "name": "Greedo",
+        "cost": {
+            "value": 1
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "hansolo": {
+        "name": "Han Solo",
+        "cost": {
+            "value": 10
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "hansolo-gunner": {
+        "name": "Han Solo",
+        "cost": {
+            "value": 10
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "hotshotgunner": {
+        "name": "Hotshot Gunner",
+        "cost": {
+            "value": 6
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "lukeskywalker": {
+        "name": "Luke Skywalker",
+        "cost": {
+            "value": 26
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "skilledbombardier": {
+        "name": "Skilled Bombardier",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "specialforcesgunner": {
+        "name": "Special Forces Gunner",
+        "cost": {
+            "value": 9
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            },
+            {
+                "ships": [
+                    "tiesffighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "veterantailgunner": {
+        "name": "Veteran Tail Gunner",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "arcs": [
+                    "Rear Arc"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "veteranturretgunner": {
+        "name": "Veteran Turret Gunner",
+        "cost": {
+            "variable": "size",
+            "values": {
+                "Small": 9,
+                "Medium": 8,
+                "Large": 7,
+                "Huge": 7
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "action": {
+                    "type": "Rotate Arc"
+                }
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "finn": {
+        "name": "Finn",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "paigetico": {
+        "name": "Paige Tico",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "rey-gunner": {
+        "name": "Rey",
+        "cost": {
+            "value": 11
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "seventhfleetgunner": {
+        "name": "Seventh Fleet Gunner",
+        "cost": {
+            "value": 6
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "clonecommandercody": {
+        "name": "Clone Commander Cody",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "ahsokatano": {
+        "name": "Ahsoka Tano",
+        "cost": {
+            "value": 9
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "clonecaptainrex": {
+        "name": "Clone Captain Rex",
+        "cost": {
+            "value": 1
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "suppressivegunner": {
+        "name": "Suppressive Gunner",
+        "cost": {
+            "value": 6
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "bobafett-gunner": {
+        "name": "Boba Fett",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "weaponssystemsofficer": {
+        "name": "Weapons Systems Officer",
+        "cost": {
+            "value": 5
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "sabinewren-gunner": {
+        "name": "Sabine Wren",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "dt798": {
+        "name": "DT-798",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "firstorderordnancetech": {
+        "name": "First Order Ordnance Tech",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "garsaxon-gunner": {
+        "name": "Gar Saxon",
+        "cost": {
+            "value": 10
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Large",
+                    "Huge"
+                ]
+            },
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "tibersaxon": {
+        "name": "Tiber Saxon",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "ursawren-gunner": {
+        "name": "Ursa Wren",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic",
+                    "separatistalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "migsmayfeld": {
+        "name": "Migs Mayfeld",
+        "cost": {
+            "variable": "size",
+            "values": {
+                "Small": 2,
+                "Medium": 3,
+                "Large": 4,
+                "Huge": 7
+            }
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire",
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Gunner"
+        ]
+    },
+    "ioncannonbattery": {
+        "name": "Ion Cannon Battery",
+        "cost": {
+            "value": 6
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Hardpoint"
+        ]
+    },
+    "ordnancetubes": {
+        "name": "Ordnance Tubes",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Hardpoint"
+        ]
+    },
+    "pointdefensebattery": {
+        "name": "Point-Defense Battery",
+        "cost": {
+            "value": 8
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Hardpoint"
+        ]
+    },
+    "targetingbattery": {
+        "name": "Targeting Battery",
+        "cost": {
+            "value": 5
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Hardpoint"
+        ]
+    },
+    "turbolaserbattery": {
+        "name": "Turbolaser Battery",
+        "cost": {
+            "value": 10
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Hardpoint"
+        ]
+    },
+    "tractortentacles": {
+        "name": "Tractor Tentacles",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Huge"
+                ]
+            },
+            {
+                "ships": [
+                    "tridentclassassaultship"
+                ]
+            }
+        ],
+        "slots": [
+            "Hardpoint"
+        ]
+    },
+    "protoncannonbattery": {
+        "name": "Proton Cannon Battery",
+        "cost": {
+            "value": 10
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Hardpoint",
+            "Cargo"
+        ]
+    },
+    "enhancedpropulsion": {
+        "name": "Enhanced Propulsion",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Huge"
+                ]
+            },
+            {
+                "ships": [
+                    "tridentclassassaultship"
+                ]
+            }
+        ],
+        "slots": [
+            "Hardpoint",
+            "Cargo"
+        ]
+    },
+    "drillbeak": {
+        "name": "Drill Beak",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Huge"
+                ]
+            },
+            {
+                "ships": [
+                    "tridentclassassaultship"
+                ]
+            }
+        ],
+        "slots": [
+            "Hardpoint",
+            "Cargo"
+        ]
+    },
+    "syliure31hyperdrive": {
+        "name": "Syliure-31 Hyperdrive",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "syliureclasshyperspacering"
+                ]
+            }
+        ],
+        "slots": [
+            "Hyperdrive"
+        ]
+    },
+    "cloakingdevice": {
+        "name": "Cloaking Device",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Small",
+                    "Medium"
+                ]
+            }
+        ],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "contrabandcybernetics": {
+        "name": "Contraband Cybernetics",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "deadmansswitch": {
+        "name": "Deadman's Switch",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "feedbackarray": {
+        "name": "Feedback Array",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "inertialdampeners": {
+        "name": "Inertial Dampeners",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 0,
+                "1": 1,
+                "2": 2,
+                "3": 3,
+                "4": 4,
+                "5": 5,
+                "6": 6,
+                "7": 7,
+                "8": 8
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "riggedcargochute": {
+        "name": "Rigged Cargo Chute",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Medium",
+                    "Large"
+                ]
+            }
+        ],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "coaxiumhyperfuel": {
+        "name": "Coaxium Hyperfuel",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "quickreleaselocks": {
+        "name": "Quick-Release Locks",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Huge"
+                ]
+            }
+        ],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "saboteursmap": {
+        "name": "Saboteur's Map",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Huge"
+                ]
+            }
+        ],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "scannerbaffler": {
+        "name": "Scanner Baffler",
+        "cost": {
+            "value": 7
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Huge"
+                ]
+            }
+        ],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "falsetranspondercodes": {
+        "name": "False Transponder Codes",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "babufrik": {
+        "name": "Babu Frik",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy",
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "overtunedmodulators": {
+        "name": "Overtuned Modulators",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "trackingfob": {
+        "name": "Tracking Fob",
+        "cost": {
+            "value": 3
+        },
+        "limited": 3,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "keywords": [
+                    "Bounty Hunter"
+                ]
+            }
+        ],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "hotshottailblaster": {
+        "name": "Hotshot Tail Blaster",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Medium",
+                    "Large"
+                ]
+            }
+        ],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "chaffparticles-rsl": {
+        "name": "Chaff Particles",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": true,
+        "epic": false,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Small"
+                ]
+            }
+        ],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "fuelinjectionoverride-rsl": {
+        "name": "Fuel Injection Override",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": true,
+        "epic": false,
+        "restrictions": [],
+        "slots": [
+            "Illicit"
+        ]
+    },
+    "barragerockets": {
+        "name": "Barrage Rockets",
+        "cost": {
+            "value": 8
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Missile",
+            "Missile"
+        ]
+    },
+    "clustermissiles": {
+        "name": "Cluster Missiles",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 3,
+                "1": 3,
+                "2": 3,
+                "3": 4,
+                "4": 4,
+                "5": 4,
+                "6": 4
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Missile"
+        ]
+    },
+    "concussionmissiles": {
+        "name": "Concussion Missiles",
+        "cost": {
+            "value": 6
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Missile"
+        ]
+    },
+    "homingmissiles": {
+        "name": "Homing Missiles",
+        "cost": {
+            "value": 5
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Missile"
+        ]
+    },
+    "ionmissiles": {
+        "name": "Ion Missiles",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Missile"
+        ]
+    },
+    "protonrockets": {
+        "name": "Proton Rockets",
+        "cost": {
+            "value": 5
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Missile"
+        ]
+    },
+    "energyshellcharges": {
+        "name": "Energy-Shell Charges",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "action": {
+                    "type": "Calculate",
+                    "difficulty": "White"
+                }
+            },
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Missile"
+        ]
+    },
+    "discordmissiles": {
+        "name": "Discord Missiles",
+        "cost": {
+            "value": 4
+        },
+        "limited": 3,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Missile"
+        ]
+    },
+    "diamondboronmissiles": {
+        "name": "Diamond-Boron Missiles",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Missile",
+            "Missile"
+        ]
+    },
+    "magpulsewarheads": {
+        "name": "Mag-Pulse Warheads",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 4,
+                "1": 4,
+                "2": 4,
+                "3": 5,
+                "4": 5,
+                "5": 5,
+                "6": 5
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Missile"
+        ]
+    },
+    "electrochaffmissiles": {
+        "name": "Electro-Chaff Missiles",
+        "cost": {
+            "value": 4
+        },
+        "limited": 2,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Missile",
+            "Device"
+        ]
+    },
+    "multimissilepods": {
+        "name": "Multi-Missile Pods",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Missile",
+            "Missile"
+        ]
+    },
+    "xx23sthreadtracers": {
+        "name": "XX-23 S-Thread Tracers",
+        "cost": {
+            "value": 4
+        },
+        "limited": 2,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Missile"
+        ]
+    },
+    "seekermissiles-rsl": {
+        "name": "Seeker Missiles",
+        "cost": {
+            "value": 5
+        },
+        "limited": 2,
+        "standard": false,
+        "wildspace": true,
+        "epic": false,
+        "restrictions": [],
+        "slots": [
+            "Missile"
+        ]
+    },
+    "ablativeplating": {
+        "name": "Ablative Plating",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Medium",
+                    "Large"
+                ]
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "advancedslam": {
+        "name": "Advanced SLAM",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "action": {
+                    "type": "SLAM",
+                    "difficulty": "White"
+                }
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "afterburners": {
+        "name": "Afterburners",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 4,
+                "1": 4,
+                "2": 4,
+                "3": 4,
+                "4": 5,
+                "5": 6,
+                "6": 7
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Small"
+                ]
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "electronicbaffle": {
+        "name": "Electronic Baffle",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "engineupgrade": {
+        "name": "Engine Upgrade",
+        "cost": {
+            "variable": "size",
+            "values": {
+                "Small": 3,
+                "Medium": 4,
+                "Large": 7
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "action": {
+                    "type": "Boost",
+                    "difficulty": "Red"
+                }
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "hullupgrade": {
+        "name": "Hull Upgrade",
+        "cost": {
+            "variable": "agility",
+            "values": {
+                "0": 2,
+                "1": 3,
+                "2": 5,
+                "3": 7
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "munitionsfailsafe": {
+        "name": "Munitions Failsafe",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "shieldupgrade": {
+        "name": "Shield Upgrade",
+        "cost": {
+            "variable": "agility",
+            "values": {
+                "0": 3,
+                "1": 4,
+                "2": 6,
+                "3": 8
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "staticdischargevanes": {
+        "name": "Static Discharge Vanes",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "stealthdevice": {
+        "name": "Stealth Device",
+        "cost": {
+            "variable": "agility",
+            "values": {
+                "0": 3,
+                "1": 4,
+                "2": 6,
+                "3": 8
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "tacticalscrambler": {
+        "name": "Tactical Scrambler",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Medium",
+                    "Large"
+                ]
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "imperviumplating": {
+        "name": "Impervium Plating",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "belbullab22starfighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "synchronizedconsole": {
+        "name": "Synchronized Console",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            },
+            {
+                "action": {
+                    "type": "Lock",
+                    "difficulty": "White"
+                }
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "sparepartscanisters": {
+        "name": "Spare Parts Canisters",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "equipped": [
+                    "Astromech"
+                ]
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "delayedfuses": {
+        "name": "Delayed Fuses",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "angleddeflectors": {
+        "name": "Angled Deflectors",
+        "cost": {
+            "variable": "agility",
+            "values": {
+                "0": 6,
+                "1": 2,
+                "2": 1,
+                "3": 1
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Small",
+                    "Medium"
+                ]
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "targetingcomputer": {
+        "name": "Targeting Computer",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "independentcalculations": {
+        "name": "Independent Calculations",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "shipAbility": [
+                    "Networked Calculations"
+                ]
+            },
+            {
+                "standardized": true
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "overdrivethruster": {
+        "name": "Overdrive Thruster",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 2,
+                "1": 3,
+                "2": 4,
+                "3": 5,
+                "4": 6,
+                "5": 7,
+                "6": 8
+            }
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "t70xwing"
+                ]
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "precisionionengines": {
+        "name": "Precision Ion Engines",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 1,
+                "1": 1,
+                "2": 1,
+                "3": 1,
+                "4": 1,
+                "5": 2,
+                "6": 2
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "keywords": [
+                    "TIE"
+                ]
+            },
+            {
+                "agility": [
+                    3
+                ]
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "mandalorianoptics": {
+        "name": "Mandalorian Optics",
+        "cost": {
+            "value": 5
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "keywords": [
+                    "Mandalorian"
+                ]
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "dropseatbay": {
+        "name": "Drop-Seat bay",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "gauntletfighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "beskarreinforcedplating": {
+        "name": "Beskar Reinforced Plating",
+        "cost": {
+            "variable": "agility",
+            "values": {
+                "0": 2,
+                "1": 3,
+                "2": 4,
+                "3": 5
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "keywords": [
+                    "Mandalorian"
+                ]
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "burnoutthrusters": {
+        "name": "Burnout Thrusters",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "sizes": [
+                    "Small",
+                    "Medium"
+                ]
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "contingencyprotocol-rsl": {
+        "name": "Contingency Protocol",
+        "cost": {
+            "variable": "size",
+            "values": {
+                "Small": 1,
+                "Medium": 2,
+                "Large": 2
+            }
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": true,
+        "epic": false,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            },
+            {
+                "equipped": [
+                    "Tactical Relay"
+                ]
+            },
+            {
+                "keywords": [
+                    "Droid"
+                ]
+            }
+        ],
+        "slots": [
+            "Modification"
+        ]
+    },
+    "advancedsensors": {
+        "name": "Advanced Sensors",
+        "cost": {
+            "variable": "size",
+            "values": {
+                "Small": 13,
+                "Medium": 11,
+                "Large": 9,
+                "Huge": 0
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Sensor"
+        ]
+    },
+    "collisiondetector": {
+        "name": "Collision Detector",
+        "cost": {
+            "value": 6
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Sensor"
+        ]
+    },
+    "firecontrolsystem": {
+        "name": "Fire-Control System",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Sensor"
+        ]
+    },
+    "trajectorysimulator": {
+        "name": "Trajectory Simulator",
+        "cost": {
+            "variable": "size",
+            "values": {
+                "Small": 5,
+                "Medium": 4,
+                "Large": 3,
+                "Huge": 3
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Sensor"
+        ]
+    },
+    "passivesensors": {
+        "name": "Passive Sensors",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 4,
+                "1": 4,
+                "2": 4,
+                "3": 4,
+                "4": 5,
+                "5": 6,
+                "6": 7,
+                "7": 4,
+                "8": 4
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Sensor"
+        ]
+    },
+    "kraken": {
+        "name": "Kraken",
+        "cost": {
+            "value": 10
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            },
+            {
+                "solitary": true
+            }
+        ],
+        "slots": [
+            "Tactical Relay"
+        ]
+    },
+    "tv94": {
+        "name": "TV-94",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            },
+            {
+                "solitary": true
+            }
+        ],
+        "slots": [
+            "Tactical Relay"
+        ]
+    },
+    "k2b4": {
+        "name": "K2-B4",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            },
+            {
+                "solitary": true
+            }
+        ],
+        "slots": [
+            "Tactical Relay"
+        ]
+    },
+    "ta175": {
+        "name": "TA-175",
+        "cost": {
+            "value": 11
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            },
+            {
+                "solitary": true
+            }
+        ],
+        "slots": [
+            "Tactical Relay"
+        ]
+    },
+    "kalani": {
+        "name": "Kalani",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Tactical Relay"
+        ]
+    },
+    "composure": {
+        "name": "Composure",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "action": {
+                    "type": "Focus"
+                }
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "crackshot": {
+        "name": "Crack Shot",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "daredevil": {
+        "name": "Daredevil",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Small"
+                ]
+            },
+            {
+                "action": {
+                    "type": "Boost",
+                    "difficulty": "White"
+                }
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "debrisgambit": {
+        "name": "Debris Gambit",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Small",
+                    "Medium"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "elusive": {
+        "name": "Elusive",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Small",
+                    "Medium"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "experthandling": {
+        "name": "Expert Handling",
+        "cost": {
+            "variable": "size",
+            "values": {
+                "Small": 2,
+                "Medium": 2,
+                "Large": 4
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "action": {
+                    "type": "Barrel Roll",
+                    "difficulty": "Red"
+                }
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "fanatical": {
+        "name": "Fanatical",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "fearless": {
+        "name": "Fearless",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "heroic": {
+        "name": "Heroic",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "intimidation": {
+        "name": "Intimidation",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "juke": {
+        "name": "Juke",
+        "cost": {
+            "value": 6
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Small",
+                    "Medium"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "lonewolf": {
+        "name": "Lone Wolf",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "marksmanship": {
+        "name": "Marksmanship",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "outmaneuver": {
+        "name": "Outmaneuver",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 5,
+                "1": 5,
+                "2": 5,
+                "3": 5,
+                "4": 6,
+                "5": 6,
+                "6": 6
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "predator": {
+        "name": "Predator",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "ruthless": {
+        "name": "Ruthless",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "saturationsalvo": {
+        "name": "Saturation Salvo",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "action": {
+                    "type": "Reload"
+                }
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "selfless": {
+        "name": "Selfless",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "squadleader": {
+        "name": "Squad Leader",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 2,
+                "1": 4,
+                "2": 5,
+                "3": 7,
+                "4": 9,
+                "5": 10,
+                "6": 12
+            }
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "swarmtactics": {
+        "name": "Swarm Tactics",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 3,
+                "1": 3,
+                "2": 3,
+                "3": 3,
+                "4": 3,
+                "5": 4,
+                "6": 5
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "trickshot": {
+        "name": "Trick Shot",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "treacherous": {
+        "name": "Treacherous",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "dedicated": {
+        "name": "Dedicated",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            },
+            {
+                "non-limited": true
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "ensnare": {
+        "name": "Ensnare",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 15,
+                "1": 15,
+                "2": 15,
+                "3": 15,
+                "4": 15,
+                "5": 16,
+                "6": 17
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "nantexclassstarfighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "snapshot": {
+        "name": "Snap Shot",
+        "cost": {
+            "variable": "size",
+            "values": {
+                "Small": 6,
+                "Medium": 7,
+                "Large": 8,
+                "Huge": 9
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "graviticdeflection": {
+        "name": "Gravitic Deflection",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "nantexclassstarfighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "proudtradition": {
+        "name": "Proud Tradition",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "deadeyeshot": {
+        "name": "Deadeye Shot",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Small",
+                    "Medium"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "backwardstailslide": {
+        "name": "Backwards Tailslide",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "keywords": [
+                    "X-wing"
+                ]
+            },
+            {
+                "equipped": [
+                    "Configuration"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "ionlimiteroverride": {
+        "name": "Ion Limiter Override",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "keywords": [
+                    "TIE"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "margsablclosure": {
+        "name": "Marg Sabl Closure",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Small",
+                    "Medium"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "starbirdslash": {
+        "name": "Starbird Slash",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "keywords": [
+                    "A-wing"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "cutthroat": {
+        "name": "Cutthroat",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "disciplined": {
+        "name": "Disciplined",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "hopeful": {
+        "name": "Hopeful",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "interloperturn": {
+        "name": "Interloper Turn",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "tieddefender"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "tierfonbellyrun": {
+        "name": "Tierfon Belly Run",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 0,
+                "1": 0,
+                "2": 0,
+                "3": 0,
+                "4": 1,
+                "5": 1,
+                "6": 1
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "keywords": [
+                    "Y-wing"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "feedbackping": {
+        "name": "Feedback Ping",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "action": {
+                    "type": "Reload"
+                }
+            },
+            {
+                "keywords": [
+                    "TIE"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "clantraining": {
+        "name": "Clan Training",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "keywords": [
+                    "Mandalorian"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "notorious": {
+        "name": "Notorious",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "equipped": [
+                    "Illicit"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "enduring": {
+        "name": "Enduring",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "noescape-rsl": {
+        "name": "No Escape",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": true,
+        "epic": false,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "non-limited": true
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "silenthunter-rsl": {
+        "name": "Silent Hunter",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": true,
+        "epic": false,
+        "restrictions": [],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "partinggift-rsl": {
+        "name": "Parting Gift",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": true,
+        "epic": false,
+        "restrictions": [],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "formedup-rsl": {
+        "name": "Formed Up",
+        "cost": {
+            "value": 1
+        },
+        "limited": 3,
+        "standard": false,
+        "wildspace": true,
+        "epic": false,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "ships": [
+                    "tielnfighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Talent"
+        ]
+    },
+    "bombardmentspecialists": {
+        "name": "Bombardment Specialists",
+        "cost": {
+            "value": 8
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Team"
+        ]
+    },
+    "commsteam": {
+        "name": "Comms Team",
+        "cost": {
+            "value": 6
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Team"
+        ]
+    },
+    "damagecontrolteam": {
+        "name": "Damage Control Team",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Team"
+        ]
+    },
+    "gunneryspecialists": {
+        "name": "Gunnery Specialists",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Team"
+        ]
+    },
+    "igrmdroids": {
+        "name": "IG-RM Droids",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Team"
+        ]
+    },
+    "ordnanceteam": {
+        "name": "Ordnance Team",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Team"
+        ]
+    },
+    "sensorexperts": {
+        "name": "Sensor Experts",
+        "cost": {
+            "value": 6
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Team"
+        ]
+    },
+    "tractortechnicians": {
+        "name": "Tractor Technicians",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Team"
+        ]
+    },
+    "corsaircrew": {
+        "name": "Corsair Crew",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            }
+        ],
+        "slots": [
+            "Team",
+            "Gunner"
+        ]
+    },
+    "droidcrew": {
+        "name": "Droid Crew",
+        "cost": {
+            "value": 5
+        },
+        "limited": 0,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            }
+        ],
+        "slots": [
+            "Team"
+        ]
+    },
+    "advancedoptics": {
+        "name": "Advanced Optics",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Tech"
+        ]
+    },
+    "ferrospherepaint": {
+        "name": "Ferrosphere Paint",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            }
+        ],
+        "slots": [
+            "Tech"
+        ]
+    },
+    "hyperspacetrackingdata": {
+        "name": "Hyperspace Tracking Data",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            },
+            {
+                "sizes": [
+                    "Large"
+                ]
+            }
+        ],
+        "slots": [
+            "Tech"
+        ]
+    },
+    "primedthrusters": {
+        "name": "Primed Thrusters",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 4,
+                "1": 5,
+                "2": 6,
+                "3": 7,
+                "4": 8,
+                "5": 9,
+                "6": 10
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Small"
+                ]
+            }
+        ],
+        "slots": [
+            "Tech"
+        ]
+    },
+    "targetingsynchronizer": {
+        "name": "Targeting Synchronizer",
+        "cost": {
+            "value": 3
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Tech"
+        ]
+    },
+    "patternanalyzer": {
+        "name": "Pattern Analyzer",
+        "cost": {
+            "value": 5
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Tech"
+        ]
+    },
+    "biohexacryptcodes": {
+        "name": "Biohexacrypt Codes",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            },
+            {
+                "action": {
+                    "type": "Lock"
+                }
+            }
+        ],
+        "slots": [
+            "Tech"
+        ]
+    },
+    "deuteriumpowercells": {
+        "name": "Deuterium Power Cells",
+        "cost": {
+            "variable": "agility",
+            "values": {
+                "0": 4,
+                "1": 5,
+                "2": 6,
+                "3": 7
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Tech",
+            "Modification"
+        ]
+    },
+    "automatedtargetpriority": {
+        "name": "Automated Target Priority",
+        "cost": {
+            "value": 1
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Tech"
+        ]
+    },
+    "sensorbuoysuite": {
+        "name": "Sensor Buoy Suite",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            },
+            {
+                "sizes": [
+                    "Medium",
+                    "Large"
+                ]
+            }
+        ],
+        "slots": [
+            "Tech"
+        ]
+    },
+    "sensorscramblers": {
+        "name": "Sensor Scramblers",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "tiewiwhispermodifiedinterceptor",
+                    "tievnsilencer"
+                ]
+            }
+        ],
+        "slots": [
+            "Tech"
+        ]
+    },
+    "andrasta": {
+        "name": "Andrasta",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "ships": [
+                    "firesprayclasspatrolcraft"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "blackone": {
+        "name": "Black One",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            },
+            {
+                "ships": [
+                    "t70xwing"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "dauntless": {
+        "name": "Dauntless",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "ships": [
+                    "vt49decimator"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "ghost": {
+        "name": "Ghost",
+        "cost": {
+            "value": 0
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "vcx100lightfreighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "havoc": {
+        "name": "Havoc",
+        "cost": {
+            "value": 0
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "ships": [
+                    "scurrgh6bomber"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "houndstooth": {
+        "name": "Hound's Tooth",
+        "cost": {
+            "value": 0
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "ships": [
+                    "yv666lightfreighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "ig2000": {
+        "name": "IG-2000",
+        "cost": {
+            "value": 0
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "ships": [
+                    "aggressorassaultfighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "landosmillenniumfalcon": {
+        "name": "Lando's Millennium Falcon",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "ships": [
+                    "customizedyt1300lightfreighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "marauder": {
+        "name": "Marauder",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "ships": [
+                    "firesprayclasspatrolcraft"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "millenniumfalcon": {
+        "name": "Millennium Falcon",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "modifiedyt1300lightfreighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "misthunter": {
+        "name": "Mist Hunter",
+        "cost": {
+            "value": 1
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "ships": [
+                    "g1astarfighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "moldycrow": {
+        "name": "Moldy Crow",
+        "cost": {
+            "value": 16
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance",
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "ships": [
+                    "hwk290lightfreighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "outrider": {
+        "name": "Outrider",
+        "cost": {
+            "value": 9
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "yt2400lightfreighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "outrider2023": {
+        "name": "Outrider (2023)",
+        "cost": {
+            "value": 7
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance",
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "ships": [
+                    "yt2400lightfreighter2023"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "phantom": {
+        "name": "Phantom",
+        "cost": {
+            "value": 0
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "attackshuttle",
+                    "sheathipedeclassshuttle"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "punishingone": {
+        "name": "Punishing One",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "ships": [
+                    "jumpmaster5000"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "st321": {
+        "name": "ST-321",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "ships": [
+                    "lambdaclasst4ashuttle"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "shadowcaster": {
+        "name": "Shadow Caster",
+        "cost": {
+            "value": 1
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "ships": [
+                    "lancerclasspursuitcraft"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "slavei": {
+        "name": "Slave I",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "ships": [
+                    "firesprayclasspatrolcraft"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "virago": {
+        "name": "Virago",
+        "cost": {
+            "value": 7
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "starviperclassattackplatform"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "reysmillenniumfalcon": {
+        "name": "Rey's Millennium Falcon",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            },
+            {
+                "ships": [
+                    "scavengedyt1300"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "soullessone": {
+        "name": "Soulless One",
+        "cost": {
+            "value": 7
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "belbullab22starfighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "scimitar": {
+        "name": "Scimitar",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "sithinfiltrator"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "assailer": {
+        "name": "Assailer",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "ships": [
+                    "raiderclasscorvette"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "bloodcrow": {
+        "name": "Blood Crow",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "ships": [
+                    "gozanticlasscruiser"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "brighthope": {
+        "name": "Bright Hope",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "gr75mediumtransport"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "brokenhorn": {
+        "name": "Broken Horn",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "ships": [
+                    "croccruiser"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "corvus": {
+        "name": "Corvus",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "ships": [
+                    "raiderclasscorvette"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "dodonnaspride": {
+        "name": "Dodonna's Pride",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "cr90corelliancorvette"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "impetuous": {
+        "name": "Impetuous",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "ships": [
+                    "raiderclasscorvette"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "insatiableworrt": {
+        "name": "Insatiable Worrt",
+        "cost": {
+            "value": 7
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "ships": [
+                    "croccruiser"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "instigator": {
+        "name": "Instigator",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "ships": [
+                    "raiderclasscorvette"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "jainaslight": {
+        "name": "Jaina's Light",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "cr90corelliancorvette"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "kazsfireball": {
+        "name": "Kaz's Fireball",
+        "cost": {
+            "value": 0
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            },
+            {
+                "ships": [
+                    "fireball"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "liberator": {
+        "name": "Liberator",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "cr90corelliancorvette"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "luminous": {
+        "name": "Luminous",
+        "cost": {
+            "value": 12
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "gr75mediumtransport"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "merchantone": {
+        "name": "Merchant One",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "ships": [
+                    "croccruiser"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "quantumstorm": {
+        "name": "Quantum Storm",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "gr75mediumtransport"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "requiem": {
+        "name": "Requiem",
+        "cost": {
+            "value": 7
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "ships": [
+                    "gozanticlasscruiser"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "suppressor": {
+        "name": "Suppressor",
+        "cost": {
+            "value": 6
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "ships": [
+                    "gozanticlasscruiser"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "tantiveiv": {
+        "name": "Tantive IV",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "cr90corelliancorvette"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "thunderstrike": {
+        "name": "Thunderstrike",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "cr90corelliancorvette"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "vector": {
+        "name": "Vector",
+        "cost": {
+            "value": 7
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticempire"
+                ]
+            },
+            {
+                "ships": [
+                    "gozanticlasscruiser"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "slavei-swz82": {
+        "name": "Slave I",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy",
+                    "separatistalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "firesprayclasspatrolcraft"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "b6bladewingprototype": {
+        "name": "B6 Blade Wing Prototype",
+        "cost": {
+            "value": 1
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "asf01bwing"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "nautolansrevenge": {
+        "name": "Nautolan's Revenge",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy"
+                ]
+            },
+            {
+                "ships": [
+                    "tridentclassassaultship"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "grappler": {
+        "name": "Grappler",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "tridentclassassaultship"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "neimoidiangrasp": {
+        "name": "Neimoidian Grasp",
+        "cost": {
+            "value": 5
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "tridentclassassaultship"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "trident": {
+        "name": "Trident",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "tridentclassassaultship"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "nightbrother": {
+        "name": "Nightbrother",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "scumandvillainy",
+                    "rebelalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "gauntletfighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Title",
+            "Modification"
+        ]
+    },
+    "gauntlet": {
+        "name": "Gauntlet",
+        "cost": {
+            "value": 3
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic",
+                    "separatistalliance"
+                ]
+            },
+            {
+                "ships": [
+                    "gauntletfighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Title",
+            "Modification"
+        ]
+    },
+    "razorcrest": {
+        "name": "Razor Crest",
+        "cost": {
+            "value": 4
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "st70assaultship"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "xanadublood": {
+        "name": "Xanadu Blood",
+        "cost": {
+            "value": 2
+        },
+        "limited": 1,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [
+            {
+                "ships": [
+                    "rogueclassstarfighter"
+                ]
+            }
+        ],
+        "slots": [
+            "Title"
+        ]
+    },
+    "homingtorpedoes": {
+        "name": "Homing Torpedoes",
+        "cost": {
+            "value": 5
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Torpedo"
+        ]
+    },
+    "advprotontorpedoes": {
+        "name": "Adv. Proton Torpedoes",
+        "cost": {
+            "value": 5
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Torpedo"
+        ]
+    },
+    "iontorpedoes": {
+        "name": "Ion Torpedoes",
+        "cost": {
+            "value": 4
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Torpedo"
+        ]
+    },
+    "protontorpedoes": {
+        "name": "Proton Torpedoes",
+        "cost": {
+            "value": 12
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Torpedo"
+        ]
+    },
+    "plasmatorpedoes": {
+        "name": "Plasma Torpedoes",
+        "cost": {
+            "variable": "initiative",
+            "values": {
+                "0": 6,
+                "1": 6,
+                "2": 6,
+                "3": 7,
+                "4": 7,
+                "5": 7,
+                "6": 7
+            }
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Torpedo"
+        ]
+    },
+    "trackingtorpedoes": {
+        "name": "Tracking Torpedoes",
+        "cost": {
+            "value": 8
+        },
+        "limited": 1,
+        "standard": false,
+        "wildspace": false,
+        "epic": true,
+        "restrictions": [
+            {
+                "sizes": [
+                    "Huge"
+                ]
+            }
+        ],
+        "slots": [
+            "Torpedo"
+        ]
+    },
+    "dorsalturret": {
+        "name": "Dorsal Turret",
+        "cost": {
+            "value": 2
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Turret"
+        ]
+    },
+    "ioncannonturret": {
+        "name": "Ion Cannon Turret",
+        "cost": {
+            "value": 5
+        },
+        "limited": 0,
+        "standard": true,
+        "wildspace": true,
+        "epic": true,
+        "restrictions": [],
+        "slots": [
+            "Turret"
+        ]
+    }
+}

--- a/X2PO/points-revisions.json
+++ b/X2PO/points-revisions.json
@@ -1,8 +1,9 @@
 {
-    "current_revision": "X2PO/mar2025/revision.json",
+    "current_revision": "X2PO/dec2025/revision.json",
     "revision_history": [
         "X2PO/mar2024/revision.json",
         "X2PO/sep2024/revision.json",
-        "X2PO/mar2025/revision.json"
+        "X2PO/mar2025/revision.json",
+        "X2PO/dec2025/revision.json"
     ]
 }


### PR DESCRIPTION
# Highlights
## Addition of Wookiee Keyword
Support has been added for the **_Wookiee_** keyword. This update is primarily for future-proofing card design, ensuring the system can handle future Wookiee-related mechanics and interactions correctly.

## Warriors and Turncoats (WaT) Pilots
New content from the Warriors and Turncoats (WaT) expansion pack has been added. This includes:

- New pilots for all factions.
- One new condition associated with one of the pilots.
https://x2po.org/f/warriors-and-turncoats-pack-preview
https://x2po.org/f/warriors-and-turncoats-pack-preview---part-2
https://x2po.org/f/warriors-and-turncoats-pack-preview---part-3

## Empire Phantom and Alpha-class Pilots (PnP)
Left Side Legal (LSL) pilots have been added for the TIE/ph Phantom and Alpha-class Star Wing, originating from the Print-and-Play (PnP) pack from AMG.

- Alpha-class Star Wing: Added new LSL configurations.
- TIE/ph Phantom: Added new LSL configurations.

Note: Standard Loadout (SL) versions of these pilots and their associated upgrades have also been added for consistency, but they are not yet adopted for Legacy play.

## Regular Points Update
A comprehensive points update has been applied across all factions to align with the latest balance changes. This includes updates for:

Rebel Alliance
Galactic Empire
Scum and Villainy
Resistance
First Order
Galactic Republic
Separatist Alliance
General Upgrades