### PR TITLE
Fix r2d2/r2d2-crew mixup in XWA, fill missing config restrictions

### DIFF
--- a/AMG/sep2024/upgrades.json
+++ b/AMG/sep2024/upgrades.json
@@ -1285,7 +1285,13 @@
         "standard": false,
         "extended": false,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "ships": [
+                    "croccruiser"
+                ]
+            }
+        ],
         "slots": [
             "Configuration"
         ]

--- a/X2PO/dec2025/upgrades.json
+++ b/X2PO/dec2025/upgrades.json
@@ -1547,7 +1547,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "ships": [
+                    "asf01bwing"
+                ]
+            }
+        ],
         "slots": [
             "Configuration"
         ]
@@ -1561,7 +1567,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "ships": [
+                    "hmpdroidgunship"
+                ]
+            }
+        ],
         "slots": [
             "Configuration"
         ]
@@ -1575,7 +1587,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "ships": [
+                    "nimbusclassvwing"
+                ]
+            }
+        ],
         "slots": [
             "Configuration"
         ]
@@ -1589,7 +1607,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "ships": [
+                    "nimbusclassvwing"
+                ]
+            }
+        ],
         "slots": [
             "Configuration"
         ]
@@ -1603,7 +1627,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "ships": [
+                    "droidtrifighter"
+                ]
+            }
+        ],
         "slots": [
             "Configuration"
         ]
@@ -1617,7 +1647,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "ships": [
+                    "tierbheavy"
+                ]
+            }
+        ],
         "slots": [
             "Configuration"
         ]
@@ -1631,7 +1667,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "ships": [
+                    "tierbheavy"
+                ]
+            }
+        ],
         "slots": [
             "Configuration"
         ]

--- a/XWA/50P20/upgrades.json
+++ b/XWA/50P20/upgrades.json
@@ -1524,7 +1524,13 @@
     "standard": false,
     "extended": false,
     "epic": true,
-    "restrictions": [],
+    "restrictions": [
+      {
+        "ships": [
+          "croccruiser"
+        ]
+      }
+    ],
     "slots": [
       "Configuration"
     ],

--- a/XWA/50P20/upgrades.json
+++ b/XWA/50P20/upgrades.json
@@ -92,7 +92,7 @@
   },
   "r2d2-crew": {
     "name": "R2-D2",
-    "cost": 8,
+    "cost": 6,
     "limited": 1,
     "standard": true,
     "extended": true,
@@ -105,7 +105,7 @@
       }
     ],
     "slots": [
-      "Astromech"
+      "Crew"
     ],
     "restricted": 0
   },
@@ -2715,7 +2715,7 @@
   },
   "r2d2": {
     "name": "R2-D2",
-    "cost": 6,
+    "cost": 8,
     "limited": 1,
     "standard": true,
     "extended": true,
@@ -2728,7 +2728,7 @@
       }
     ],
     "slots": [
-      "Crew"
+      "Astromech"
     ],
     "restricted": 0
   },


### PR DESCRIPTION
- XWA: r2d2 and r2d2-crew had each other's slot and cost (AMG and X2PO have them the right way around). Swapped back: r2d2 = Astromech 8, r2d2-crew = Crew 6.
- XWA + AMG: corsairrefit restrictions [] -> croccruiser (copied from X2PO)
- X2PO: stabilizedsfoils, repulsorliftstabilizers, alpha3bbesh, alpha3eesk, interceptbooster, maneuverassistmgk300, targetassistmgk300 restrictions [] -> their ships (copied from XWA/AMG)