### PR TITLE
Fill missing printed-card equip restrictions (23 X2PO, 1 AMG)

### DIFF
--- a/AMG/sep2024/upgrades.json
+++ b/AMG/sep2024/upgrades.json
@@ -4945,7 +4945,7 @@
         "standard": true,
         "extended": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [{ "action": { "type": "SLAM" } }],
         "slots": [
             "Illicit"
         ]

--- a/X2PO/dec2025/upgrades.json
+++ b/X2PO/dec2025/upgrades.json
@@ -485,7 +485,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
         "slots": [
             "Astromech"
         ]
@@ -748,7 +754,18 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "resistance"
+                ]
+            },
+            {
+                "keywords": [
+                    "X-wing"
+                ]
+            }
+        ],
         "slots": [
             "Cannon"
         ]
@@ -3269,7 +3286,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
         "slots": [
             "Crew"
         ]
@@ -3283,7 +3306,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            }
+        ],
         "slots": [
             "Crew"
         ]
@@ -3297,7 +3326,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
         "slots": [
             "Crew"
         ]
@@ -3317,7 +3352,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
         "slots": [
             "Crew"
         ]
@@ -3345,7 +3386,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
         "slots": [
             "Crew"
         ]
@@ -3359,7 +3406,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
         "slots": [
             "Crew"
         ]
@@ -3373,7 +3426,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
         "slots": [
             "Crew"
         ]
@@ -3387,7 +3446,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
         "slots": [
             "Crew",
             "Gunner"
@@ -3402,7 +3467,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            }
+        ],
         "slots": [
             "Crew"
         ]
@@ -3416,7 +3487,18 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            },
+            {
+                "action": {
+                    "type": "Rotate Arc"
+                }
+            }
+        ],
         "slots": [
             "Crew",
             "Gunner"
@@ -3431,7 +3513,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            }
+        ],
         "slots": [
             "Crew"
         ]
@@ -4563,7 +4651,18 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "sizes": [
+                    "Small"
+                ]
+            },
+            {
+                "action": {
+                    "type": "Boost"
+                }
+            }
+        ],
         "slots": [
             "Force Power"
         ]
@@ -5087,7 +5186,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
         "slots": [
             "Gunner"
         ]
@@ -5101,7 +5206,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "galacticrepublic"
+                ]
+            }
+        ],
         "slots": [
             "Gunner"
         ]
@@ -5129,7 +5240,14 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance",
+                    "scumandvillainy"
+                ]
+            }
+        ],
         "slots": [
             "Gunner"
         ]
@@ -5157,7 +5275,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "rebelalliance"
+                ]
+            }
+        ],
         "slots": [
             "Gunner"
         ]
@@ -5596,7 +5720,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "action": {
+                    "type": "SLAM"
+                }
+            }
+        ],
         "slots": [
             "Illicit"
         ]
@@ -6769,7 +6899,16 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "separatistalliance"
+                ]
+            },
+            {
+                "solitary": true
+            }
+        ],
         "slots": [
             "Tactical Relay"
         ]
@@ -7935,7 +8074,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "action": {
+                    "type": "Lock"
+                }
+            }
+        ],
         "slots": [
             "Tech"
         ]
@@ -7994,7 +8139,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "factions": [
+                    "firstorder"
+                ]
+            }
+        ],
         "slots": [
             "Tech",
             "Modification"
@@ -8009,7 +8160,13 @@
         "standard": true,
         "wildspace": true,
         "epic": true,
-        "restrictions": [],
+        "restrictions": [
+            {
+                "initiative": [
+                    "3 OR LOWER"
+                ]
+            }
+        ],
         "slots": [
             "Tech"
         ]


### PR DESCRIPTION
24 upgrade entries publish `"restrictions": []` while the printed card carries an equip lock, so a consumer that trusts the field lets, e.g., Yoda crew onto a Scum ship in X2PO. This fills exactly those entries; nothing the feed already restricts is touched, and no cost/legality value moves.

Sources, per rule set's own documents (not cross-copied from another feed):
- **X2PO**: 10 are explicit in the points sheet's Restrictions column; 9 are Republic-only crew whose faction is encoded by the sheet TAB; `bobafett-gunner` matches "Separatist or Scum" on both tabs; `targetingsynchronizer` / `extrememaneuvers` / `automatedtargetpriority` / `coaxiumhyperfuel` carry the sheet's action/initiative markers.
- **AMG**: `coaxiumhyperfuel` — the Upgrade Points document prints the SLAM glyph for it (the same glyph as Advanced SLAM).

Deliberately NOT touched: XWA's `coaxiumhyperfuel`, whose Restrictions cell in the XWA points PDF is genuinely empty — XWA doesn't gate that card on SLAM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)